### PR TITLE
Ensure tokens removed from Integration response

### DIFF
--- a/src/LexosHub.ERP.VarejoOnline.Api/Controllers/Integration/IntegrationController.cs
+++ b/src/LexosHub.ERP.VarejoOnline.Api/Controllers/Integration/IntegrationController.cs
@@ -35,7 +35,11 @@ namespace LexosHub.ERP.VarejoOnline.Api.Controllers.Integration
                 if (!result.IsSuccess)
                     return new BadRequestObjectResult(result);
 
+                // Never return sensitive authentication data to the client
+                // Tokens are cleared before sending the response
                 result.Result.Password = string.Empty;
+                result.Result.RefreshToken = string.Empty;
+                result.Result.Token = string.Empty;
 
                 return new OkObjectResult(result);
             }

--- a/src/LexosHub.ERP.VarejoOnline.Domain/DTOs/Integration/IntegrationDto.cs
+++ b/src/LexosHub.ERP.VarejoOnline.Domain/DTOs/Integration/IntegrationDto.cs
@@ -15,5 +15,17 @@
         public DateTime UpdatedDate { get; set; }
         public DateTime? LastOrderSyncDate { get; set; }
         public bool HasValidVersion { get; set; }
+
+        /// <summary>
+        /// Token de autenticação da integração. Este valor não deve ser retornado
+        /// pelas APIs.
+        /// </summary>
+        public string? Token { get; set; }
+
+        /// <summary>
+        /// RefreshToken utilizado para obter novo Token. Este valor não deve ser
+        /// retornado pelas APIs.
+        /// </summary>
+        public string? RefreshToken { get; set; }
     }
 }


### PR DESCRIPTION
## Summary
- add `Token` and `RefreshToken` fields to `IntegrationDto` with docs
- clear token fields in `IntegrationController` before returning the response

## Testing
- `dotnet build LexosHub.VarejoOnline.sln -c Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685592ec51488328b030d1a3aac84be2