### PR TITLE
Integrate AWS SQS listener service

### DIFF
--- a/src/LexosHub.ERP.VarejoOnline.Api/LexosHub.ERP.VarejoOnline.Api.csproj
+++ b/src/LexosHub.ERP.VarejoOnline.Api/LexosHub.ERP.VarejoOnline.Api.csproj
@@ -32,6 +32,7 @@
     <PackageReference Include="Serilog.Formatting.Compact" Version="1.1.0" />
     <PackageReference Include="Serilog.Sinks.Datadog.Logs" Version="0.5.2" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+    <PackageReference Include="AWSSDK.Extensions.NETCore.Setup" Version="3.7.0" />
   </ItemGroup>
 
   <ItemGroup>
@@ -49,7 +50,8 @@
     <ProjectReference Include="..\LexosHub.ERP.VarejoOnline.Infra.CrossCutting\LexosHub.ERP.VarejoOnline.Infra.CrossCutting.csproj" />
     <ProjectReference Include="..\LexosHub.ERP.VarejoOnline.Infra.Data.Migrations\LexosHub.ERP.VarejoOnline.Infra.Data.Migrations.csproj" />
     <ProjectReference Include="..\LexosHub.ERP.VarejoOnline.Infra.Data\LexosHub.ERP.VarejoOnline.Infra.Data.csproj" />
-    
+    <ProjectReference Include="..\LexosHub.ERP.VarejoOnline.Infra.Messaging\LexosHub.ERP.VarejoOnline.Infra.Messaging.csproj" />
+
   </ItemGroup>
 
 </Project>

--- a/src/LexosHub.ERP.VarejoOnline.Api/Program.cs
+++ b/src/LexosHub.ERP.VarejoOnline.Api/Program.cs
@@ -12,6 +12,11 @@ using LexosHub.ERP.VarejoOnline.Infra.Data.Repositories.Persistence;
 using LexosHub.ERP.VarejoOnline.Infra.VarejoOnlineApi.Services;
 using LexosHub.ERP.VarejoOnline.Infra.Data.Repositories.Integration;
 using LexosHub.ERP.VarejoOnline.Infra.Data.Repositories.Persistence;
+using LexosHub.ERP.VarejoOnline.Infra.Messaging.Dispatcher;
+using LexosHub.ERP.VarejoOnline.Infra.Messaging.Events;
+using LexosHub.ERP.VarejoOnline.Infra.Messaging.Handlers;
+using LexosHub.ERP.VarejoOnline.Infra.Messaging.Services;
+using Amazon.SQS;
 using Microsoft.EntityFrameworkCore;
 using Serilog;
 using System.Diagnostics;
@@ -46,6 +51,11 @@ try
     builder.Services.AddFluentValidationAutoValidation(conf => { conf.DisableDataAnnotationsValidation = true; });
 
     builder.Services.AddOptions<VarejoOnlineApiSettings>().Bind(builder.Configuration.GetSection(nameof(VarejoOnlineApiSettings)));
+
+    builder.Services.AddAWSService<IAmazonSQS>();
+    builder.Services.AddSingleton<IEventDispatcher, EventDispatcher>();
+    builder.Services.AddTransient<IEventHandler<OrderCreatedEvent>, OrderCreatedEventHandler>();
+    builder.Services.AddHostedService<SqsListenerService>();
 
     var app = builder.Build().SetupMiddlewares();
 


### PR DESCRIPTION
## Summary
- add Amazon SQS and messaging service registrations in Program.cs
- reference messaging project and AWS extensions in API project

## Testing
- `dotnet build LexosHub.VarejoOnline.sln -c Release` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68595f1ecce08328b4ccc43cd098e39e