### PR TITLE
Fix namespace for IEventHandler

### DIFF
--- a/src/LexosHub.ERP.VarejoOnline.Infra.Messaging/Handlers/IEventHandler.cs
+++ b/src/LexosHub.ERP.VarejoOnline.Infra.Messaging/Handlers/IEventHandler.cs
@@ -1,6 +1,6 @@
 using System.Threading;
 using System.Threading.Tasks;
-using LexosHub.ERP.Winthor.Infra.Messaging.Events;
+using LexosHub.ERP.VarejoOnline.Infra.Messaging.Events;
 
 namespace LexosHub.ERP.VarejoOnline.Infra.Messaging.Handlers
 {


### PR DESCRIPTION
## Summary
- correct namespace in IEventHandler to reference VarejoOnline events

## Testing
- `dotnet build LexosHub.VarejoOnline.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859604850e483288c8f77c0149b3953