### PR TITLE
Add basic unit tests for VarejoOnlineApiService

### DIFF
--- a/tests/LexosHub.ERP.VarejoOnline.Domain.Tests/Services/VarejoOnlineApiServiceTests.cs
+++ b/tests/LexosHub.ERP.VarejoOnline.Domain.Tests/Services/VarejoOnlineApiServiceTests.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Options;
+using Xunit;
+using LexosHub.ERP.VarejoOnline.Infra.CrossCutting.Settings;
+using LexosHub.ERP.VarejoOnline.Infra.VarejoOnlineApi.Services;
+
+namespace LexosHub.ERP.VarejoOnline.Domain.Tests.Services
+{
+    public class VarejoOnlineApiServiceTests
+    {
+        private static VarejoOnlineApiService CreateService(VarejoOnlineApiSettings settings)
+        {
+            return new VarejoOnlineApiService(Options.Create(settings));
+        }
+
+        [Fact]
+        public void Constructor_WithEmptyBaseUrl_ShouldThrow()
+        {
+            var settings = new VarejoOnlineApiSettings { BaseUrl = string.Empty };
+            Assert.Throws<ArgumentNullException>(() => CreateService(settings));
+        }
+
+        [Fact]
+        public async Task GetAuthUrl_ShouldReturnExpectedUrl()
+        {
+            var settings = new VarejoOnlineApiSettings
+            {
+                BaseUrl = "https://api/",
+                OAuthUrl = "oauth?",
+                ClientId = "id",
+                OAuthRedirectUrl = "redir"
+            };
+            var service = CreateService(settings);
+
+            var url = await service.GetAuthUrl();
+
+            Assert.Equal("https://api/oauth?client_id=id&redirect_uri=redir", url);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add unit tests for VarejoOnlineApiService

## Testing
- `dotnet test tests/LexosHub.ERP.VarejoOnline.Domain.Tests/LexosHub.ERP.VarejoOnline.Domain.Tests.csproj` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d87233c40832899ed44b4176eec13