### PR TITLE
Add event handler unit tests

### DIFF
--- a/tests/LexosHub.ERP.VarejoOnline.Domain.Tests/LexosHub.ERP.VarejoOnline.Domain.Tests.csproj
+++ b/tests/LexosHub.ERP.VarejoOnline.Domain.Tests/LexosHub.ERP.VarejoOnline.Domain.Tests.csproj
@@ -12,5 +12,6 @@
     <ProjectReference Include="..\..\src\LexosHub.ERP.VarejoOnline.Domain\LexosHub.ERP.VarejoOnline.Domain.csproj" />
     <ProjectReference Include="..\..\src\LexosHub.ERP.VarejoOnline.Infra.CrossCutting\LexosHub.ERP.VarejoOnline.Infra.CrossCutting.csproj" />
     <ProjectReference Include="..\..\src\LexosHub.ERP.VarejoOnline.Infra.ErpApi\LexosHub.ERP.VarejoOnline.Infra.ErpApi.csproj" />
+    <ProjectReference Include="..\..\src\LexosHub.ERP.VarejoOnline.Infra.Messaging\LexosHub.ERP.VarejoOnline.Infra.Messaging.csproj" />
   </ItemGroup>
 </Project>

--- a/tests/LexosHub.ERP.VarejoOnline.Domain.Tests/Messaging/EventDispatcherTests.cs
+++ b/tests/LexosHub.ERP.VarejoOnline.Domain.Tests/Messaging/EventDispatcherTests.cs
@@ -1,0 +1,30 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Moq;
+using Xunit;
+using Microsoft.Extensions.DependencyInjection;
+using LexosHub.ERP.VarejoOnline.Infra.Messaging.Dispatcher;
+using LexosHub.ERP.VarejoOnline.Infra.Messaging.Events;
+using LexosHub.ERP.VarejoOnline.Infra.Messaging.Handlers;
+
+namespace LexosHub.ERP.VarejoOnline.Domain.Tests.Messaging
+{
+    public class EventDispatcherTests
+    {
+        [Fact]
+        public async Task DispatchAsync_ShouldInvokeRegisteredHandler()
+        {
+            var handlerMock = new Mock<IEventHandler<IntegrationCreated>>();
+            var services = new ServiceCollection();
+            services.AddSingleton<IEventHandler<IntegrationCreated>>(handlerMock.Object);
+            using var provider = services.BuildServiceProvider();
+            var scopeFactory = provider.GetRequiredService<IServiceScopeFactory>();
+            var dispatcher = new EventDispatcher(scopeFactory);
+
+            var evt = new IntegrationCreated();
+            await dispatcher.DispatchAsync(evt, CancellationToken.None);
+
+            handlerMock.Verify(h => h.HandleAsync(evt, It.IsAny<CancellationToken>()), Times.Once);
+        }
+    }
+}

--- a/tests/LexosHub.ERP.VarejoOnline.Domain.Tests/Messaging/IntegrationCreatedEventHandlerTests.cs
+++ b/tests/LexosHub.ERP.VarejoOnline.Domain.Tests/Messaging/IntegrationCreatedEventHandlerTests.cs
@@ -1,0 +1,45 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Moq;
+using Xunit;
+using Microsoft.Extensions.Logging;
+using LexosHub.ERP.VarejoOnline.Infra.Messaging.Handlers;
+using LexosHub.ERP.VarejoOnline.Infra.Messaging.Events;
+using LexosHub.ERP.VarejoOnline.Domain.DTOs.Integration;
+using LexosHub.ERP.VarejoOnline.Domain.Interfaces.Services;
+
+namespace LexosHub.ERP.VarejoOnline.Domain.Tests.Messaging
+{
+    public class IntegrationCreatedEventHandlerTests
+    {
+        private readonly Mock<ILogger<IntegrationCreatedEventHandler>> _logger = new();
+        private readonly Mock<IIntegrationService> _integrationService = new();
+
+        private IntegrationCreatedEventHandler CreateHandler()
+            => new IntegrationCreatedEventHandler(_logger.Object, _integrationService.Object);
+
+        [Fact]
+        public async Task HandleAsync_ShouldCallAddOrUpdateIntegration()
+        {
+            var evt = new IntegrationCreated
+            {
+                HubIntegrationId = 1,
+                TenantId = 2,
+                HubKey = "key",
+                Cnpj = "123"
+            };
+
+            await CreateHandler().HandleAsync(evt, CancellationToken.None);
+
+            _integrationService.Verify(s => s.AddOrUpdateIntegrationAsync(
+                It.Is<HubIntegracaoDto>(d =>
+                    d.IntegracaoId == evt.HubIntegrationId &&
+                    d.TenantId == evt.TenantId &&
+                    d.Chave == evt.HubKey &&
+                    d.Cnpj == evt.Cnpj &&
+                    d.Habilitado &&
+                    d.Excluido == false
+                )), Times.Once);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- test IntegrationCreatedEventHandler
- test EventDispatcher generic dispatch
- reference messaging project in tests

## Testing
- `dotnet test tests/LexosHub.ERP.VarejoOnline.Domain.Tests/LexosHub.ERP.VarejoOnline.Domain.Tests.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d88ef5e2c8328abb9b5f8213cc23f