### PR TITLE
Add product and stock endpoints to API service

### DIFF
--- a/src/LexosHub.ERP.VarejoOnline.Infra.ErpApi/Interfaces/IVarejoOnlineApiService.cs
+++ b/src/LexosHub.ERP.VarejoOnline.Infra.ErpApi/Interfaces/IVarejoOnlineApiService.cs
@@ -10,4 +10,6 @@ public interface IVarejoOnlineApiService
     Task<string> GetAuthUrl();
     Task<Response<List<EmpresaResponse>>> GetEmpresasAsync(EmpresaRequest request);
     public Task<Response<List<TabelaPrecoListResponse>>> GetPriceTablesAsync(int? inicio = null, int? quantidade = null, string? alteradoApos = null, string? entidades = null);
+    Task<Response<List<ProdutoResponse>>> GetProdutosAsync(ProdutoRequest request);
+    Task<Response<List<EstoqueResponse>>> GetEstoquesAsync(EstoqueRequest request);
 }

--- a/src/LexosHub.ERP.VarejoOnline.Infra.ErpApi/Responses/Estoque/EstoqueRequest.cs
+++ b/src/LexosHub.ERP.VarejoOnline.Infra.ErpApi/Responses/Estoque/EstoqueRequest.cs
@@ -1,0 +1,14 @@
+namespace LexosHub.ERP.VarejoOnline.Infra.VarejoOnlineApi.Request
+{
+    public class EstoqueRequest
+    {
+        public string? Produtos { get; set; }
+        public string? Entidades { get; set; }
+        public int? Inicio { get; set; }
+        public int? Quantidade { get; set; }
+        public string? AlteradoApos { get; set; }
+        public string? Data { get; set; }
+        public bool? SomenteEcommerce { get; set; }
+        public bool? SomenteMarketplace { get; set; }
+    }
+}

--- a/src/LexosHub.ERP.VarejoOnline.Infra.ErpApi/Responses/Estoque/EstoqueResponse.cs
+++ b/src/LexosHub.ERP.VarejoOnline.Infra.ErpApi/Responses/Estoque/EstoqueResponse.cs
@@ -1,0 +1,27 @@
+namespace LexosHub.ERP.VarejoOnline.Infra.VarejoOnlineApi.Responses
+{
+    public class EstoqueResponse
+    {
+        public EntidadeResponse Entidade { get; set; } = new();
+        public ProdutoEstoqueResponse Produto { get; set; } = new();
+        public decimal Quantidade { get; set; }
+        public string? DataAlteracao { get; set; }
+        public string? Data { get; set; }
+    }
+
+    public class EntidadeResponse
+    {
+        public long Id { get; set; }
+        public string Nome { get; set; } = string.Empty;
+        public string Documento { get; set; } = string.Empty;
+    }
+
+    public class ProdutoEstoqueResponse
+    {
+        public long Id { get; set; }
+        public string Descricao { get; set; } = string.Empty;
+        public string? CodigoSistema { get; set; }
+        public string? CodigoInterno { get; set; }
+        public string? CodigoBarras { get; set; }
+    }
+}

--- a/src/LexosHub.ERP.VarejoOnline.Infra.ErpApi/Responses/Produto/ProdutoRequest.cs
+++ b/src/LexosHub.ERP.VarejoOnline.Infra.ErpApi/Responses/Produto/ProdutoRequest.cs
@@ -1,0 +1,27 @@
+namespace LexosHub.ERP.VarejoOnline.Infra.VarejoOnlineApi.Request
+{
+    public class ProdutoRequest
+    {
+        public long? Id { get; set; }
+        public int? Inicio { get; set; }
+        public int? Quantidade { get; set; }
+        public string? AlteradoApos { get; set; }
+        public string? Categoria { get; set; }
+        public long? ProdutoBase { get; set; }
+        public string? Descricao { get; set; }
+        public string? CodigoBarras { get; set; }
+        public string? CodigoInterno { get; set; }
+        public string? CodigoSistema { get; set; }
+        public bool? SomenteAtivos { get; set; }
+        public bool? SomenteComFotos { get; set; }
+        public bool? SomenteEcommerce { get; set; }
+        public bool? SomenteMarketplace { get; set; }
+        public bool? AmostraGratis { get; set; }
+        public string? AlteracaoDesde { get; set; }
+        public string? AlteracaoAte { get; set; }
+        public string? CriacaoDesde { get; set; }
+        public string? CriacaoAte { get; set; }
+        public string? IdsProdutos { get; set; }
+        public string? IdsTabelasPrecos { get; set; }
+    }
+}

--- a/src/LexosHub.ERP.VarejoOnline.Infra.ErpApi/Responses/Produto/ProdutoResponse.cs
+++ b/src/LexosHub.ERP.VarejoOnline.Infra.ErpApi/Responses/Produto/ProdutoResponse.cs
@@ -1,0 +1,16 @@
+namespace LexosHub.ERP.VarejoOnline.Infra.VarejoOnlineApi.Responses
+{
+    public class ProdutoResponse
+    {
+        public long Id { get; set; }
+        public bool Ativo { get; set; }
+        public string? DataAlteracao { get; set; }
+        public string? DataCriacao { get; set; }
+        public string Descricao { get; set; } = string.Empty;
+        public string? DescricaoSimplificada { get; set; }
+        public string? CodigoBarras { get; set; }
+        public string? CodigoInterno { get; set; }
+        public string? CodigoSistema { get; set; }
+        public decimal? Preco { get; set; }
+    }
+}

--- a/src/LexosHub.ERP.VarejoOnline.Infra.ErpApi/Services/VarejoOnlineApiService.cs
+++ b/src/LexosHub.ERP.VarejoOnline.Infra.ErpApi/Services/VarejoOnlineApiService.cs
@@ -122,6 +122,109 @@ namespace LexosHub.ERP.VarejoOnline.Infra.VarejoOnlineApi.Services
         }
         #endregion
 
+        #region Produtos
+        public async Task<Response<List<ProdutoResponse>>> GetProdutosAsync(ProdutoRequest request)
+        {
+            var resource = request.Id.HasValue ? $"produtos/{request.Id.Value}" : "produtos";
+            var restRequest = new RestRequest(resource, Method.Get);
+
+            if (request.Inicio.HasValue)
+                restRequest.AddQueryParameter("inicio", request.Inicio.Value.ToString());
+
+            if (request.Quantidade.HasValue)
+                restRequest.AddQueryParameter("quantidade", request.Quantidade.Value.ToString());
+
+            if (!string.IsNullOrWhiteSpace(request.AlteradoApos))
+                restRequest.AddQueryParameter("alteradoApos", request.AlteradoApos);
+
+            if (!string.IsNullOrWhiteSpace(request.Categoria))
+                restRequest.AddQueryParameter("categoria", request.Categoria);
+
+            if (request.ProdutoBase.HasValue)
+                restRequest.AddQueryParameter("produtoBase", request.ProdutoBase.Value.ToString());
+
+            if (!string.IsNullOrWhiteSpace(request.Descricao))
+                restRequest.AddQueryParameter("descricao", request.Descricao);
+
+            if (!string.IsNullOrWhiteSpace(request.CodigoBarras))
+                restRequest.AddQueryParameter("codigoBarras", request.CodigoBarras);
+
+            if (!string.IsNullOrWhiteSpace(request.CodigoInterno))
+                restRequest.AddQueryParameter("codigoInterno", request.CodigoInterno);
+
+            if (!string.IsNullOrWhiteSpace(request.CodigoSistema))
+                restRequest.AddQueryParameter("codigoSistema", request.CodigoSistema);
+
+            if (request.SomenteAtivos.HasValue)
+                restRequest.AddQueryParameter("somenteAtivos", request.SomenteAtivos.Value.ToString().ToLower());
+
+            if (request.SomenteComFotos.HasValue)
+                restRequest.AddQueryParameter("somenteComFotos", request.SomenteComFotos.Value.ToString().ToLower());
+
+            if (request.SomenteEcommerce.HasValue)
+                restRequest.AddQueryParameter("somenteEcommerce", request.SomenteEcommerce.Value.ToString().ToLower());
+
+            if (request.SomenteMarketplace.HasValue)
+                restRequest.AddQueryParameter("somenteMarketplace", request.SomenteMarketplace.Value.ToString().ToLower());
+
+            if (request.AmostraGratis.HasValue)
+                restRequest.AddQueryParameter("amostraGratis", request.AmostraGratis.Value.ToString().ToLower());
+
+            if (!string.IsNullOrWhiteSpace(request.AlteracaoDesde))
+                restRequest.AddQueryParameter("alteracaoDesde", request.AlteracaoDesde);
+
+            if (!string.IsNullOrWhiteSpace(request.AlteracaoAte))
+                restRequest.AddQueryParameter("alteracaoAte", request.AlteracaoAte);
+
+            if (!string.IsNullOrWhiteSpace(request.CriacaoDesde))
+                restRequest.AddQueryParameter("criacaoDesde", request.CriacaoDesde);
+
+            if (!string.IsNullOrWhiteSpace(request.CriacaoAte))
+                restRequest.AddQueryParameter("criacaoAte", request.CriacaoAte);
+
+            if (!string.IsNullOrWhiteSpace(request.IdsProdutos))
+                restRequest.AddQueryParameter("idsProdutos", request.IdsProdutos);
+
+            if (!string.IsNullOrWhiteSpace(request.IdsTabelasPrecos))
+                restRequest.AddQueryParameter("idsTabelasPrecos", request.IdsTabelasPrecos);
+
+            return await ExecuteAsync<List<ProdutoResponse>>(restRequest);
+        }
+        #endregion
+
+        #region Estoques
+        public async Task<Response<List<EstoqueResponse>>> GetEstoquesAsync(EstoqueRequest request)
+        {
+            var restRequest = new RestRequest("saldos-mercadorias", Method.Get);
+
+            if (!string.IsNullOrWhiteSpace(request.Produtos))
+                restRequest.AddQueryParameter("produtos", request.Produtos);
+
+            if (!string.IsNullOrWhiteSpace(request.Entidades))
+                restRequest.AddQueryParameter("entidades", request.Entidades);
+
+            if (request.Inicio.HasValue)
+                restRequest.AddQueryParameter("inicio", request.Inicio.Value.ToString());
+
+            if (request.Quantidade.HasValue)
+                restRequest.AddQueryParameter("quantidade", request.Quantidade.Value.ToString());
+
+            if (!string.IsNullOrWhiteSpace(request.AlteradoApos))
+                restRequest.AddQueryParameter("alteradoApos", request.AlteradoApos);
+
+            if (!string.IsNullOrWhiteSpace(request.Data))
+                restRequest.AddQueryParameter("data", request.Data);
+
+            if (request.SomenteEcommerce.HasValue)
+                restRequest.AddQueryParameter("somenteEcommerce", request.SomenteEcommerce.Value.ToString().ToLower());
+
+            if (request.SomenteMarketplace.HasValue)
+                restRequest.AddQueryParameter("somenteMarketplace", request.SomenteMarketplace.Value.ToString().ToLower());
+
+            return await ExecuteAsync<List<EstoqueResponse>>(restRequest);
+        }
+        #endregion
+
         #region Utils
         private async Task<Response<T>> ExecuteAsync<T>(RestRequest request)
         {


### PR DESCRIPTION
## Summary
- implement ProdutoRequest/ProdutoResponse
- implement EstoqueRequest/EstoqueResponse
- extend IVarejoOnlineApiService with new methods
- implement GetProdutosAsync and GetEstoquesAsync in VarejoOnlineApiService

## Testing
- `dotnet test --no-build` *(fails: `dotnet` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d8b7d1b648328947de14534ddd756