### PR TITLE
Fix integration retrieval by hub key

### DIFF
--- a/src/LexosHub.ERP.VarejoOnline.Infra.Data/Repositories/Integration/IntegrationRepository.cs
+++ b/src/LexosHub.ERP.VarejoOnline.Infra.Data/Repositories/Integration/IntegrationRepository.cs
@@ -264,10 +264,12 @@ namespace LexosHub.ERP.VarejoOnline.Infra.Data.Repositories.Integration
                            ,[UpdatedDate]
                            ,[LastSyncDate]
                            ,[HasValidVersion]
-                       FROM
-                           [Integration] NOLOCK
-                       ORDER BY
-                           [CreatedDate] DESC",
+                        FROM
+                            [Integration] NOLOCK
+                        WHERE
+                            [HubKey] = @HubKey
+                        ORDER BY
+                            [CreatedDate] DESC",
                     param: new { HubKey = key });
             }
             catch (Exception e)


### PR DESCRIPTION
## Summary
- filter by `HubKey` when searching for an integration using `GetByKeyAsync`

## Testing
- `dotnet test --no-build` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685d940eaa0c83288b757ed59df39f30