### PR TITLE
Fix csproj BOM

### DIFF
--- a/src/LexosHub.ERP.VarejoOnline.Api/LexosHub.ERP.VarejoOnline.Api.csproj
+++ b/src/LexosHub.ERP.VarejoOnline.Api/LexosHub.ERP.VarejoOnline.Api.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>net7.0</TargetFramework>


### PR DESCRIPTION
## Summary
- remove byte-order mark from `LexosHub.ERP.VarejoOnline.Api.csproj`

## Testing
- `dotnet test --no-build` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685e950f2544832882a68e77dff7a715