### PR TITLE
Add ProductsPageProcessed event and paginate products request

### DIFF
--- a/src/LexosHub.ERP.VarejoOnline.Infra.Messaging/Events/ProductsPageProcessed.cs
+++ b/src/LexosHub.ERP.VarejoOnline.Infra.Messaging/Events/ProductsPageProcessed.cs
@@ -1,0 +1,11 @@
+namespace LexosHub.ERP.VarejoOnline.Infra.Messaging.Events
+{
+    public class ProductsPageProcessed : BaseEvent
+    {
+        public string HubKey { get; set; } = null!;
+        public int Start { get; set; }
+        public int PageSize { get; set; }
+        public int ProcessedCount { get; set; }
+    }
+}
+

--- a/src/LexosHub.ERP.VarejoOnline.Infra.Messaging/Handlers/ProductsRequestedEventHandler.cs
+++ b/src/LexosHub.ERP.VarejoOnline.Infra.Messaging/Handlers/ProductsRequestedEventHandler.cs
@@ -1,6 +1,7 @@
 using LexosHub.ERP.VarejoOnline.Domain.Interfaces.Services;
 using LexosHub.ERP.VarejoOnline.Infra.Messaging.Events;
 using LexosHub.ERP.VarejoOnline.Infra.VarejoOnlineApi.Request;
+using LexosHub.ERP.VarejoOnline.Infra.Messaging.Dispatcher;
 using Microsoft.Extensions.Logging;
 
 namespace LexosHub.ERP.VarejoOnline.Infra.Messaging.Handlers
@@ -10,15 +11,18 @@ namespace LexosHub.ERP.VarejoOnline.Infra.Messaging.Handlers
         private readonly ILogger<ProductsRequestedEventHandler> _logger;
         private readonly IIntegrationService _integrationService;
         private readonly IVarejoOnlineApiService _apiService;
+        private readonly IEventDispatcher _dispatcher;
 
         public ProductsRequestedEventHandler(
             ILogger<ProductsRequestedEventHandler> logger,
             IIntegrationService integrationService,
-            IVarejoOnlineApiService apiService)
+            IVarejoOnlineApiService apiService,
+            IEventDispatcher dispatcher)
         {
             _logger = logger;
             _integrationService = integrationService;
             _apiService = apiService;
+            _dispatcher = dispatcher;
         }
 
         public async Task HandleAsync(ProductsRequested @event, CancellationToken cancellationToken)
@@ -28,32 +32,53 @@ namespace LexosHub.ERP.VarejoOnline.Infra.Messaging.Handlers
             var integrationResponse = await _integrationService.GetIntegrationByKeyAsync(@event.HubKey);
             var token = integrationResponse.Result?.Token ?? string.Empty;
 
-            var request = new ProdutoRequest
-            {
-                Id = @event.Id,
-                Inicio = @event.Inicio,
-                Quantidade = @event.Quantidade,
-                AlteradoApos = @event.AlteradoApos,
-                Categoria = @event.Categoria,
-                ProdutoBase = @event.ProdutoBase,
-                Descricao = @event.Descricao,
-                CodigoBarras = @event.CodigoBarras,
-                CodigoInterno = @event.CodigoInterno,
-                CodigoSistema = @event.CodigoSistema,
-                SomenteAtivos = @event.SomenteAtivos,
-                SomenteComFotos = @event.SomenteComFotos,
-                SomenteEcommerce = @event.SomenteEcommerce,
-                SomenteMarketplace = @event.SomenteMarketplace,
-                AmostraGratis = @event.AmostraGratis,
-                AlteracaoDesde = @event.AlteracaoDesde,
-                AlteracaoAte = @event.AlteracaoAte,
-                CriacaoDesde = @event.CriacaoDesde,
-                CriacaoAte = @event.CriacaoAte,
-                IdsProdutos = @event.IdsProdutos,
-                IdsTabelasPrecos = @event.IdsTabelasPrecos
-            };
+            var start = @event.Inicio ?? 0;
+            var pageSize = @event.Quantidade ?? 50;
+            int count;
 
-            await _apiService.GetProdutosAsync(token, request);
+            do
+            {
+                var request = new ProdutoRequest
+                {
+                    Id = @event.Id,
+                    Inicio = start,
+                    Quantidade = pageSize,
+                    AlteradoApos = @event.AlteradoApos,
+                    Categoria = @event.Categoria,
+                    ProdutoBase = @event.ProdutoBase,
+                    Descricao = @event.Descricao,
+                    CodigoBarras = @event.CodigoBarras,
+                    CodigoInterno = @event.CodigoInterno,
+                    CodigoSistema = @event.CodigoSistema,
+                    SomenteAtivos = @event.SomenteAtivos,
+                    SomenteComFotos = @event.SomenteComFotos,
+                    SomenteEcommerce = @event.SomenteEcommerce,
+                    SomenteMarketplace = @event.SomenteMarketplace,
+                    AmostraGratis = @event.AmostraGratis,
+                    AlteracaoDesde = @event.AlteracaoDesde,
+                    AlteracaoAte = @event.AlteracaoAte,
+                    CriacaoDesde = @event.CriacaoDesde,
+                    CriacaoAte = @event.CriacaoAte,
+                    IdsProdutos = @event.IdsProdutos,
+                    IdsTabelasPrecos = @event.IdsTabelasPrecos
+                };
+
+                var response = await _apiService.GetProdutosAsync(token, request);
+                count = response.Result?.Count ?? 0;
+
+                var pageEvent = new ProductsPageProcessed
+                {
+                    HubKey = @event.HubKey,
+                    Start = start,
+                    PageSize = pageSize,
+                    ProcessedCount = count
+                };
+
+                await _dispatcher.DispatchAsync(pageEvent, cancellationToken);
+
+                start += pageSize;
+            } while (count >= pageSize);
         }
     }
 }
+

--- a/src/LexosHub.ERP.VarejoOnline.Infra.Messaging/Resolver/EntityTypeResolver.cs
+++ b/src/LexosHub.ERP.VarejoOnline.Infra.Messaging/Resolver/EntityTypeResolver.cs
@@ -9,7 +9,8 @@ namespace LexosHub.ERP.VarejoOnline.Infra.Messaging.Dispatcher
         private static readonly Dictionary<string, Type> EventTypeMap = new()
         {
             { "IntegrationCreated", typeof(IntegrationCreated) },
-            { "ProductsRequested", typeof(ProductsRequested) }
+            { "ProductsRequested", typeof(ProductsRequested) },
+            { "ProductsPageProcessed", typeof(ProductsPageProcessed) }
             // Adicione outros eventos aqui
         };
 
@@ -22,3 +23,4 @@ namespace LexosHub.ERP.VarejoOnline.Infra.Messaging.Dispatcher
         }
     }
 }
+

--- a/tests/LexosHub.ERP.VarejoOnline.Domain.Tests/Messaging/ProductsRequestedEventHandlerTests.cs
+++ b/tests/LexosHub.ERP.VarejoOnline.Domain.Tests/Messaging/ProductsRequestedEventHandlerTests.cs
@@ -4,6 +4,8 @@ using LexosHub.ERP.VarejoOnline.Infra.CrossCutting.Default;
 using LexosHub.ERP.VarejoOnline.Infra.Messaging.Events;
 using LexosHub.ERP.VarejoOnline.Infra.Messaging.Handlers;
 using LexosHub.ERP.VarejoOnline.Infra.VarejoOnlineApi.Request;
+using LexosHub.ERP.VarejoOnline.Infra.Messaging.Dispatcher;
+using LexosHub.ERP.VarejoOnline.Infra.VarejoOnlineApi.Responses;
 using Microsoft.Extensions.Logging;
 using Moq;
 using System.Threading;
@@ -17,9 +19,10 @@ namespace LexosHub.ERP.VarejoOnline.Domain.Tests.Messaging
         private readonly Mock<ILogger<ProductsRequestedEventHandler>> _logger = new();
         private readonly Mock<IIntegrationService> _integrationService = new();
         private readonly Mock<IVarejoOnlineApiService> _apiService = new();
+        private readonly Mock<IEventDispatcher> _dispatcher = new();
 
         private ProductsRequestedEventHandler CreateHandler() =>
-            new ProductsRequestedEventHandler(_logger.Object, _integrationService.Object, _apiService.Object);
+            new ProductsRequestedEventHandler(_logger.Object, _integrationService.Object, _apiService.Object, _dispatcher.Object);
 
         [Fact]
         public async Task HandleAsync_ShouldFetchIntegrationAndCallApiService()
@@ -43,5 +46,47 @@ namespace LexosHub.ERP.VarejoOnline.Domain.Tests.Messaging
                     It.Is<ProdutoRequest>(r => r.Id == evt.Id && r.Quantidade == evt.Quantidade)
                 ), Times.Once);
         }
+
+        [Fact]
+        public async Task HandleAsync_ShouldProcessAllPagesAndDispatchEvents()
+        {
+            var evt = new ProductsRequested
+            {
+                HubKey = "key",
+                Quantidade = 2
+            };
+
+            var integration = new IntegrationDto { Token = "token" };
+            _integrationService.Setup(s => s.GetIntegrationByKeyAsync("key"))
+                .ReturnsAsync(new Response<IntegrationDto>(integration));
+
+            var firstPage = new List<ProdutoResponse> { new(), new() };
+            var secondPage = new List<ProdutoResponse> { new() };
+
+            _apiService.SetupSequence(a => a.GetProdutosAsync("token", It.IsAny<ProdutoRequest>()))
+                .ReturnsAsync(new Response<List<ProdutoResponse>>(firstPage))
+                .ReturnsAsync(new Response<List<ProdutoResponse>>(secondPage));
+
+            await CreateHandler().HandleAsync(evt, CancellationToken.None);
+
+            _apiService.Verify(a => a.GetProdutosAsync(
+                    "token",
+                    It.Is<ProdutoRequest>(r => r.Inicio == 0 && r.Quantidade == 2)
+                ), Times.Once);
+
+            _apiService.Verify(a => a.GetProdutosAsync(
+                    "token",
+                    It.Is<ProdutoRequest>(r => r.Inicio == 2 && r.Quantidade == 2)
+                ), Times.Once);
+
+            _dispatcher.Verify(d => d.DispatchAsync(
+                    It.Is<ProductsPageProcessed>(p => p.Start == 0 && p.PageSize == 2 && p.ProcessedCount == 2 && p.HubKey == "key"),
+                    It.IsAny<CancellationToken>()), Times.Once);
+
+            _dispatcher.Verify(d => d.DispatchAsync(
+                    It.Is<ProductsPageProcessed>(p => p.Start == 2 && p.PageSize == 2 && p.ProcessedCount == 1 && p.HubKey == "key"),
+                    It.IsAny<CancellationToken>()), Times.Once);
+        }
     }
 }
+


### PR DESCRIPTION
## Summary
- create `ProductsPageProcessed` event carrying pagination information
- register it in `EventTypeResolver`
- iterate over pages in `ProductsRequestedEventHandler` and dispatch `ProductsPageProcessed` for each page
- update unit tests for the new behaviour

## Testing
- `dotnet test --no-build` *(fails: `bash: dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6862c80f168483289cf0e57cc8242a6b