### PR TITLE
Capture inserted ID for integrations

### DIFF
--- a/src/LexosHub.ERP.VarejoOnline.Infra.Data/Repositories/Integration/IntegrationRepository.cs
+++ b/src/LexosHub.ERP.VarejoOnline.Infra.Data/Repositories/Integration/IntegrationRepository.cs
@@ -25,7 +25,7 @@ namespace LexosHub.ERP.VarejoOnline.Infra.Data.Repositories.Integration
         {
             try
             {
-                await _writeDbConnection.ExecuteAsync(
+                var id = await _writeDbConnection.ExecuteScalarAsync<int>(
                     sql: @"INSERT INTO [Integration]
                            (
                                [HubIntegrationId]
@@ -65,10 +65,10 @@ namespace LexosHub.ERP.VarejoOnline.Infra.Data.Repositories.Integration
                         integration.Token,
                         integration.RefreshToken,
                         integration.IsActive,
-                        integration.Id,
                         integration.HasValidVersion
                     }
                 );
+                integration.Id = id;
 
                 return integration;
             }

--- a/tests/LexosHub.ERP.VarejoOnline.Domain.Tests/Services/IntegrationServiceTests.cs
+++ b/tests/LexosHub.ERP.VarejoOnline.Domain.Tests/Services/IntegrationServiceTests.cs
@@ -28,12 +28,14 @@ namespace LexosHub.ERP.VarejoOnline.Domain.Tests.Services
             var service = CreateService();
 
             _repo.Setup(r => r.AddAsync(It.IsAny<IntegrationDto>()))
+                .Callback<IntegrationDto>(i => i.Id = 10)
                 .ReturnsAsync((IntegrationDto i) => i);
 
             var response = await service.AddIntegrationAsync(dto);
 
             Assert.True(response.IsSuccess);
             Assert.Equal(dto.Chave, response.Result?.HubKey);
+            Assert.Equal(10, response.Result?.Id);
             _repo.Verify(r => r.AddAsync(It.IsAny<IntegrationDto>()), Times.Once);
         }
 


### PR DESCRIPTION
## Summary
- retrieve inserted row ID when adding integrations
- ensure AddAsync updates the DTO's `Id`
- validate `AddIntegrationAsync` populates the ID

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862ce2d90548328b7ca2848434a71a1