### PR TITLE
Refactor SQS listener

### DIFF
--- a/src/LexosHub.ERP.VarejoOnline.Api/appsettings.json
+++ b/src/LexosHub.ERP.VarejoOnline.Api/appsettings.json
@@ -27,9 +27,9 @@
     "Region": "us-east-1",
     "ServiceURL": "http://localhost:9324/",
     "UseHttp": true,
-    "SQSQueues": {
-      "IntegrationQueue": "queue/integration-created-sync-varejoonline-dev"
-    }
+    "SQSQueues": [
+      "queue/integration-created-sync-varejoonline-dev"
+    ]
   },
   "VarejoOnlineApiSettings": {
     "ClientId": "68434c79ad8bca385602f2d9",


### PR DESCRIPTION
## Summary
- remove hard coded queue name in `SqsListenerService`
- use the configured queue URL when receiving messages
- support multiple SQS queues using an array in configuration

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863fda08cb08328b112f8821a3650de