### PR TITLE
Add ProductsPageProcessed event handler

### DIFF
--- a/src/LexosHub.ERP.VarejoOnline.Api/Program.cs
+++ b/src/LexosHub.ERP.VarejoOnline.Api/Program.cs
@@ -66,6 +66,7 @@ try
     builder.Services.AddSingleton<IEventDispatcher, EventDispatcher>();
     builder.Services.AddTransient<IEventHandler<IntegrationCreated>, IntegrationCreatedEventHandler>();
     builder.Services.AddTransient<IEventHandler<ProductsRequested>, ProductsRequestedEventHandler>();
+    builder.Services.AddTransient<IEventHandler<ProductsPageProcessed>, ProductsPageProcessedEventHandler>();
     builder.Services.AddHostedService<SqsListenerService>();
 
     var app = builder.Build().SetupMiddlewares();

--- a/src/LexosHub.ERP.VarejoOnline.Infra.Messaging/Handlers/ProductsPageProcessedEventHandler.cs
+++ b/src/LexosHub.ERP.VarejoOnline.Infra.Messaging/Handlers/ProductsPageProcessedEventHandler.cs
@@ -1,0 +1,29 @@
+using LexosHub.ERP.VarejoOnline.Infra.Messaging.Events;
+using Microsoft.Extensions.Logging;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace LexosHub.ERP.VarejoOnline.Infra.Messaging.Handlers
+{
+    public class ProductsPageProcessedEventHandler : IEventHandler<ProductsPageProcessed>
+    {
+        private readonly ILogger<ProductsPageProcessedEventHandler> _logger;
+
+        public ProductsPageProcessedEventHandler(ILogger<ProductsPageProcessedEventHandler> logger)
+        {
+            _logger = logger;
+        }
+
+        public Task HandleAsync(ProductsPageProcessed @event, CancellationToken cancellationToken)
+        {
+            _logger.LogInformation(
+                "Pgina processada recebida. Hub: {HubKey}, Incio: {Start}, Quantidade: {PageSize}, Processados: {ProcessedCount}",
+                @event.HubKey,
+                @event.Start,
+                @event.PageSize,
+                @event.ProcessedCount);
+
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/tests/LexosHub.ERP.VarejoOnline.Domain.Tests/Messaging/ProductsPageProcessedEventHandlerTests.cs
+++ b/tests/LexosHub.ERP.VarejoOnline.Domain.Tests/Messaging/ProductsPageProcessedEventHandlerTests.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+using LexosHub.ERP.VarejoOnline.Infra.Messaging.Events;
+using LexosHub.ERP.VarejoOnline.Infra.Messaging.Handlers;
+
+namespace LexosHub.ERP.VarejoOnline.Domain.Tests.Messaging
+{
+    public class ProductsPageProcessedEventHandlerTests
+    {
+        private readonly Mock<ILogger<ProductsPageProcessedEventHandler>> _logger = new();
+
+        private ProductsPageProcessedEventHandler CreateHandler() =>
+            new ProductsPageProcessedEventHandler(_logger.Object);
+
+        [Fact]
+        public async Task HandleAsync_ShouldLogInformation()
+        {
+            var evt = new ProductsPageProcessed
+            {
+                HubKey = "key",
+                Start = 1,
+                PageSize = 2,
+                ProcessedCount = 2
+            };
+
+            await CreateHandler().HandleAsync(evt, CancellationToken.None);
+
+            _logger.Verify(
+                x => x.Log(
+                    LogLevel.Information,
+                    It.IsAny<EventId>(),
+                    It.Is<It.IsAnyType>((v, t) => v.ToString().Contains("key")),
+                    It.IsAny<Exception>(),
+                    It.IsAny<Func<It.IsAnyType, Exception, string>>()),
+                Times.Once);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- log pagination events via `ProductsPageProcessedEventHandler`
- register the new handler in the API
- test handler logging

## Testing
- `dotnet test --no-build --verbosity normal` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68667b09c1608328aad54f1f67773e24