### PR TITLE
Add CompaniesRequested event handler

### DIFF
--- a/src/LexosHub.ERP.VarejoOnline.Api/Program.cs
+++ b/src/LexosHub.ERP.VarejoOnline.Api/Program.cs
@@ -67,6 +67,7 @@ try
     builder.Services.AddTransient<IEventHandler<IntegrationCreated>, IntegrationCreatedEventHandler>();
     builder.Services.AddTransient<IEventHandler<ProductsRequested>, ProductsRequestedEventHandler>();
     builder.Services.AddTransient<IEventHandler<ProductsPageProcessed>, ProductsPageProcessedEventHandler>();
+    builder.Services.AddTransient<IEventHandler<CompaniesRequested>, CompaniesRequestedEventHandler>();
     builder.Services.AddHostedService<SqsListenerService>();
 
     var app = builder.Build().SetupMiddlewares();

--- a/src/LexosHub.ERP.VarejoOnline.Infra.Messaging/Events/CompaniesRequested.cs
+++ b/src/LexosHub.ERP.VarejoOnline.Infra.Messaging/Events/CompaniesRequested.cs
@@ -1,0 +1,14 @@
+namespace LexosHub.ERP.VarejoOnline.Infra.Messaging.Events
+{
+    public class CompaniesRequested : BaseEvent
+    {
+        public string HubKey { get; set; } = null!;
+        public int? Inicio { get; set; }
+        public int? Quantidade { get; set; }
+        public string? AlteradoApos { get; set; }
+        public string? Status { get; set; }
+        public string? CampoCustomizadoNome { get; set; }
+        public string? CampoCustomizadoValor { get; set; }
+        public string? Cnpj { get; set; }
+    }
+}

--- a/src/LexosHub.ERP.VarejoOnline.Infra.Messaging/Handlers/CompaniesRequestedEventHandler.cs
+++ b/src/LexosHub.ERP.VarejoOnline.Infra.Messaging/Handlers/CompaniesRequestedEventHandler.cs
@@ -1,0 +1,45 @@
+using LexosHub.ERP.VarejoOnline.Domain.Interfaces.Services;
+using LexosHub.ERP.VarejoOnline.Infra.Messaging.Events;
+using LexosHub.ERP.VarejoOnline.Infra.VarejoOnlineApi.Request;
+using Microsoft.Extensions.Logging;
+
+namespace LexosHub.ERP.VarejoOnline.Infra.Messaging.Handlers
+{
+    public class CompaniesRequestedEventHandler : IEventHandler<CompaniesRequested>
+    {
+        private readonly ILogger<CompaniesRequestedEventHandler> _logger;
+        private readonly IIntegrationService _integrationService;
+        private readonly IVarejoOnlineApiService _apiService;
+
+        public CompaniesRequestedEventHandler(
+            ILogger<CompaniesRequestedEventHandler> logger,
+            IIntegrationService integrationService,
+            IVarejoOnlineApiService apiService)
+        {
+            _logger = logger;
+            _integrationService = integrationService;
+            _apiService = apiService;
+        }
+
+        public async Task HandleAsync(CompaniesRequested @event, CancellationToken cancellationToken)
+        {
+            _logger.LogInformation("Companies requested for hub {HubKey}", @event.HubKey);
+
+            var integrationResponse = await _integrationService.GetIntegrationByKeyAsync(@event.HubKey);
+            var token = integrationResponse.Result?.Token ?? string.Empty;
+
+            var request = new EmpresaRequest
+            {
+                Inicio = @event.Inicio,
+                Quantidade = @event.Quantidade,
+                AlteradoApos = @event.AlteradoApos,
+                Status = @event.Status,
+                CampoCustomizadoNome = @event.CampoCustomizadoNome,
+                CampoCustomizadoValor = @event.CampoCustomizadoValor,
+                Cnpj = @event.Cnpj
+            };
+
+            await _apiService.GetEmpresasAsync(token, request);
+        }
+    }
+}

--- a/src/LexosHub.ERP.VarejoOnline.Infra.Messaging/Resolver/EntityTypeResolver.cs
+++ b/src/LexosHub.ERP.VarejoOnline.Infra.Messaging/Resolver/EntityTypeResolver.cs
@@ -10,7 +10,8 @@ namespace LexosHub.ERP.VarejoOnline.Infra.Messaging.Dispatcher
         {
             { "IntegrationCreated", typeof(IntegrationCreated) },
             { "ProductsRequested", typeof(ProductsRequested) },
-            { "ProductsPageProcessed", typeof(ProductsPageProcessed) }
+            { "ProductsPageProcessed", typeof(ProductsPageProcessed) },
+            { "CompaniesRequested", typeof(CompaniesRequested) }
             // Adicione outros eventos aqui
         };
 

--- a/tests/LexosHub.ERP.VarejoOnline.Domain.Tests/Messaging/CompaniesRequestedEventHandlerTests.cs
+++ b/tests/LexosHub.ERP.VarejoOnline.Domain.Tests/Messaging/CompaniesRequestedEventHandlerTests.cs
@@ -1,0 +1,54 @@
+using LexosHub.ERP.VarejoOnline.Domain.DTOs.Integration;
+using LexosHub.ERP.VarejoOnline.Domain.Interfaces.Services;
+using LexosHub.ERP.VarejoOnline.Infra.CrossCutting.Default;
+using LexosHub.ERP.VarejoOnline.Infra.Messaging.Events;
+using LexosHub.ERP.VarejoOnline.Infra.Messaging.Handlers;
+using LexosHub.ERP.VarejoOnline.Infra.VarejoOnlineApi.Request;
+using Microsoft.Extensions.Logging;
+using Moq;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace LexosHub.ERP.VarejoOnline.Domain.Tests.Messaging
+{
+    public class CompaniesRequestedEventHandlerTests
+    {
+        private readonly Mock<ILogger<CompaniesRequestedEventHandler>> _logger = new();
+        private readonly Mock<IIntegrationService> _integrationService = new();
+        private readonly Mock<IVarejoOnlineApiService> _apiService = new();
+
+        private CompaniesRequestedEventHandler CreateHandler() =>
+            new CompaniesRequestedEventHandler(_logger.Object, _integrationService.Object, _apiService.Object);
+
+        [Fact]
+        public async Task HandleAsync_ShouldFetchIntegrationAndCallApiService()
+        {
+            var evt = new CompaniesRequested
+            {
+                HubKey = "key",
+                Quantidade = 5
+            };
+
+            var integration = new IntegrationDto { Token = "token" };
+            _integrationService.Setup(s => s.GetIntegrationByKeyAsync("key"))
+                .ReturnsAsync(new Response<IntegrationDto>(integration));
+
+            await CreateHandler().HandleAsync(evt, CancellationToken.None);
+
+            _integrationService.Verify(s => s.GetIntegrationByKeyAsync("key"), Times.Once);
+            _apiService.Verify(a => a.GetEmpresasAsync(
+                    "token",
+                    It.Is<EmpresaRequest>(r =>
+                        r.Inicio == evt.Inicio &&
+                        r.Quantidade == evt.Quantidade &&
+                        r.AlteradoApos == evt.AlteradoApos &&
+                        r.Status == evt.Status &&
+                        r.CampoCustomizadoNome == evt.CampoCustomizadoNome &&
+                        r.CampoCustomizadoValor == evt.CampoCustomizadoValor &&
+                        r.Cnpj == evt.Cnpj
+                    )
+                ), Times.Once);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- support company request events by adding `CompaniesRequested` and an event handler
- register the new event type
- wire the handler in Program.cs
- test that the handler fetches the integration and calls the API

## Testing
- `dotnet test tests/LexosHub.ERP.VarejoOnline.Domain.Tests/LexosHub.ERP.VarejoOnline.Domain.Tests.csproj -c Release -v minimal` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_686682355c248328a94dec00c9096388