### PR TITLE
Add base event constructor and tests

### DIFF
--- a/src/LexosHub.ERP.VarejoOnline.Infra.Messaging/Events/BaseEvent.cs
+++ b/src/LexosHub.ERP.VarejoOnline.Infra.Messaging/Events/BaseEvent.cs
@@ -2,6 +2,11 @@ namespace LexosHub.ERP.VarejoOnline.Infra.Messaging.Events
 {
     public class BaseEvent
     {
-        public string EventType { get; set; } = null!;
+        public string EventType { get; private set; } = null!;
+
+        protected BaseEvent()
+        {
+            EventType = GetType().Name;
+        }
     }
 }

--- a/src/LexosHub.ERP.VarejoOnline.Infra.Messaging/Resolver/EntityTypeResolver.cs
+++ b/src/LexosHub.ERP.VarejoOnline.Infra.Messaging/Resolver/EntityTypeResolver.cs
@@ -11,7 +11,8 @@ namespace LexosHub.ERP.VarejoOnline.Infra.Messaging.Dispatcher
             { "IntegrationCreated", typeof(IntegrationCreated) },
             { "ProductsRequested", typeof(ProductsRequested) },
             { "ProductsPageProcessed", typeof(ProductsPageProcessed) },
-            { "CompaniesRequested", typeof(CompaniesRequested) }
+            { "CompaniesRequested", typeof(CompaniesRequested) },
+            { "InitialSync", typeof(InitialSync) }
             // Adicione outros eventos aqui
         };
 

--- a/tests/LexosHub.ERP.VarejoOnline.Domain.Tests/Messaging/EventTypeTests.cs
+++ b/tests/LexosHub.ERP.VarejoOnline.Domain.Tests/Messaging/EventTypeTests.cs
@@ -1,0 +1,40 @@
+using System.Collections.Generic;
+using System.Text.Json;
+using LexosHub.ERP.VarejoOnline.Infra.Messaging.Dispatcher;
+using LexosHub.ERP.VarejoOnline.Infra.Messaging.Events;
+using Xunit;
+
+namespace LexosHub.ERP.VarejoOnline.Domain.Tests.Messaging
+{
+    public class EventTypeTests
+    {
+        public static IEnumerable<object[]> Events => new List<object[]>
+        {
+            new object[] { new IntegrationCreated() },
+            new object[] { new CompaniesRequested() },
+            new object[] { new ProductsRequested() },
+            new object[] { new ProductsPageProcessed() },
+            new object[] { new InitialSync() }
+        };
+
+        [Theory]
+        [MemberData(nameof(Events))]
+        public void Constructor_Should_Set_EventType_To_Class_Name(BaseEvent evt)
+        {
+            Assert.Equal(evt.GetType().Name, evt.EventType);
+        }
+
+        [Theory]
+        [MemberData(nameof(Events))]
+        public void EventTypeResolver_Should_Deserialize_To_Correct_Type(BaseEvent evt)
+        {
+            var json = JsonSerializer.Serialize(evt);
+            var envelope = JsonSerializer.Deserialize<BaseEvent>(json);
+            var actualType = EventTypeResolver.Resolve(envelope!.EventType);
+            var deserialized = (BaseEvent)JsonSerializer.Deserialize(json, actualType)!;
+
+            Assert.IsType(evt.GetType(), deserialized);
+            Assert.Equal(evt.EventType, deserialized.EventType);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- set up BaseEvent to initialize `EventType` using a protected constructor
- register `InitialSync` in `EventTypeResolver`
- test that all events set `EventType` correctly and deserialize via resolver

## Testing
- `dotnet test --no-build --verbosity minimal` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68668aee3b488328a1caa210406ca7ab