### PR TITLE
Add mapper for VarejoOnline products

### DIFF
--- a/src/LexosHub.ERP.VarejoOnline.Domain/Mappers/VarejoOnlineProdutoMapper.cs
+++ b/src/LexosHub.ERP.VarejoOnline.Domain/Mappers/VarejoOnlineProdutoMapper.cs
@@ -1,0 +1,41 @@
+using System.Collections.Generic;
+using Lexos.Hub.Sync.Models.Produto;
+
+namespace LexosHub.ERP.VarejoOnline.Domain.Mappers
+{
+    public static class VarejoOnlineProdutoMapper
+    {
+        public static List<VarejoOnlineProduto> Map(List<VarejoOnlineProdutoDto>? source)
+        {
+            var result = new List<VarejoOnlineProduto>();
+            if (source == null)
+            {
+                return result;
+            }
+
+            foreach (var item in source)
+            {
+                if (item == null)
+                {
+                    continue;
+                }
+
+                var mapped = new VarejoOnlineProduto
+                {
+                    ProdutoIdGlobal = item.id,
+                    Nome = item.descricao,
+                    DescricaoResumida = item.descricaoSimplificada,
+                    Ean = item.codigoBarras,
+                    Peso = item.peso,
+                    Comprimento = item.comprimento,
+                    Largura = item.largura,
+                    Altura = item.altura
+                };
+
+                result.Add(mapped);
+            }
+
+            return result;
+        }
+    }
+}

--- a/src/LexosHub.ERP.VarejoOnline.Domain/Models/Produto/VarejoOnlineProduto.cs
+++ b/src/LexosHub.ERP.VarejoOnline.Domain/Models/Produto/VarejoOnlineProduto.cs
@@ -1,0 +1,14 @@
+namespace Lexos.Hub.Sync.Models.Produto
+{
+    public class VarejoOnlineProduto
+    {
+        public long ProdutoIdGlobal { get; set; }
+        public string? Nome { get; set; }
+        public string? DescricaoResumida { get; set; }
+        public string? Ean { get; set; }
+        public decimal? Peso { get; set; }
+        public decimal? Comprimento { get; set; }
+        public decimal? Largura { get; set; }
+        public decimal? Altura { get; set; }
+    }
+}

--- a/src/LexosHub.ERP.VarejoOnline.Domain/Models/Produto/VarejoOnlineProdutoDto.cs
+++ b/src/LexosHub.ERP.VarejoOnline.Domain/Models/Produto/VarejoOnlineProdutoDto.cs
@@ -1,0 +1,14 @@
+namespace Lexos.Hub.Sync.Models.Produto
+{
+    public class VarejoOnlineProdutoDto
+    {
+        public long id { get; set; }
+        public string? descricao { get; set; }
+        public string? descricaoSimplificada { get; set; }
+        public string? codigoBarras { get; set; }
+        public decimal? peso { get; set; }
+        public decimal? comprimento { get; set; }
+        public decimal? largura { get; set; }
+        public decimal? altura { get; set; }
+    }
+}

--- a/tests/LexosHub.ERP.VarejoOnline.Domain.Tests/Mappers/VarejoOnlineProdutoMapperTests.cs
+++ b/tests/LexosHub.ERP.VarejoOnline.Domain.Tests/Mappers/VarejoOnlineProdutoMapperTests.cs
@@ -1,0 +1,51 @@
+using System.Collections.Generic;
+using Lexos.Hub.Sync.Models.Produto;
+using LexosHub.ERP.VarejoOnline.Domain.Mappers;
+using Xunit;
+
+namespace LexosHub.ERP.VarejoOnline.Domain.Tests.Mappers
+{
+    public class VarejoOnlineProdutoMapperTests
+    {
+        [Fact]
+        public void Map_ShouldHandleNullInput()
+        {
+            var result = VarejoOnlineProdutoMapper.Map(null);
+
+            Assert.NotNull(result);
+            Assert.Empty(result);
+        }
+
+        [Fact]
+        public void Map_ShouldMapFieldsCorrectly()
+        {
+            var source = new List<VarejoOnlineProdutoDto>
+            {
+                new VarejoOnlineProdutoDto
+                {
+                    id = 10,
+                    descricao = "Produto X",
+                    descricaoSimplificada = "Prod X",
+                    codigoBarras = "123",
+                    peso = 1.5m,
+                    comprimento = 2.5m,
+                    largura = 3.5m,
+                    altura = 4.5m
+                }
+            };
+
+            var result = VarejoOnlineProdutoMapper.Map(source);
+
+            Assert.Single(result);
+            var item = result[0];
+            Assert.Equal(10, item.ProdutoIdGlobal);
+            Assert.Equal("Produto X", item.Nome);
+            Assert.Equal("Prod X", item.DescricaoResumida);
+            Assert.Equal("123", item.Ean);
+            Assert.Equal(1.5m, item.Peso);
+            Assert.Equal(2.5m, item.Comprimento);
+            Assert.Equal(3.5m, item.Largura);
+            Assert.Equal(4.5m, item.Altura);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- map `VarejoOnlineProdutoDto` objects to sync model `VarejoOnlineProduto`
- define minimal product models for mapping
- test mapper behaviour

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686bd79f65a083288e6d402bc9b74c1a