### PR TITLE
Add missing InitialSync handlers

### DIFF
--- a/src/LexosHub.ERP.VarejoOnline.Api/Program.cs
+++ b/src/LexosHub.ERP.VarejoOnline.Api/Program.cs
@@ -65,6 +65,7 @@ try
     });
     builder.Services.AddSingleton<IEventDispatcher, EventDispatcher>();
     builder.Services.AddTransient<IEventHandler<IntegrationCreated>, IntegrationCreatedEventHandler>();
+    builder.Services.AddTransient<IEventHandler<InitialSync>, InitialSyncEventHandler>();
     builder.Services.AddTransient<IEventHandler<ProductsRequested>, ProductsRequestedEventHandler>();
     builder.Services.AddTransient<IEventHandler<ProductsPageProcessed>, ProductsPageProcessedEventHandler>();
     builder.Services.AddTransient<IEventHandler<CompaniesRequested>, CompaniesRequestedEventHandler>();

--- a/src/LexosHub.ERP.VarejoOnline.Infra.Messaging/Events/InitialSync.cs
+++ b/src/LexosHub.ERP.VarejoOnline.Infra.Messaging/Events/InitialSync.cs
@@ -8,5 +8,6 @@ namespace LexosHub.ERP.VarejoOnline.Infra.Messaging.Events
 {
     public class InitialSync : BaseEvent
     {
+        public string HubKey { get; set; } = null!;
     }
 }

--- a/src/LexosHub.ERP.VarejoOnline.Infra.Messaging/Handlers/CompaniesRequestedEventHandler.cs
+++ b/src/LexosHub.ERP.VarejoOnline.Infra.Messaging/Handlers/CompaniesRequestedEventHandler.cs
@@ -1,4 +1,5 @@
 using LexosHub.ERP.VarejoOnline.Domain.Interfaces.Services;
+using LexosHub.ERP.VarejoOnline.Infra.Messaging.Dispatcher;
 using LexosHub.ERP.VarejoOnline.Infra.Messaging.Events;
 using LexosHub.ERP.VarejoOnline.Infra.VarejoOnlineApi.Request;
 using Microsoft.Extensions.Logging;
@@ -10,15 +11,18 @@ namespace LexosHub.ERP.VarejoOnline.Infra.Messaging.Handlers
         private readonly ILogger<CompaniesRequestedEventHandler> _logger;
         private readonly IIntegrationService _integrationService;
         private readonly IVarejoOnlineApiService _apiService;
+        private readonly IEventDispatcher _dispatcher;
 
         public CompaniesRequestedEventHandler(
             ILogger<CompaniesRequestedEventHandler> logger,
             IIntegrationService integrationService,
-            IVarejoOnlineApiService apiService)
+            IVarejoOnlineApiService apiService,
+            IEventDispatcher dispatcher)
         {
             _logger = logger;
             _integrationService = integrationService;
             _apiService = apiService;
+            _dispatcher = dispatcher;
         }
 
         public async Task HandleAsync(CompaniesRequested @event, CancellationToken cancellationToken)
@@ -40,6 +44,9 @@ namespace LexosHub.ERP.VarejoOnline.Infra.Messaging.Handlers
             };
 
             await _apiService.GetEmpresasAsync(token, request);
+
+            var productsEvent = new ProductsRequested { HubKey = @event.HubKey };
+            await _dispatcher.DispatchAsync(productsEvent, cancellationToken);
         }
     }
 }

--- a/src/LexosHub.ERP.VarejoOnline.Infra.Messaging/Handlers/InitialSyncEventHandler.cs
+++ b/src/LexosHub.ERP.VarejoOnline.Infra.Messaging/Handlers/InitialSyncEventHandler.cs
@@ -1,0 +1,26 @@
+using LexosHub.ERP.VarejoOnline.Infra.Messaging.Dispatcher;
+using LexosHub.ERP.VarejoOnline.Infra.Messaging.Events;
+using Microsoft.Extensions.Logging;
+
+namespace LexosHub.ERP.VarejoOnline.Infra.Messaging.Handlers
+{
+    public class InitialSyncEventHandler : IEventHandler<InitialSync>
+    {
+        private readonly ILogger<InitialSyncEventHandler> _logger;
+        private readonly IEventDispatcher _dispatcher;
+
+        public InitialSyncEventHandler(ILogger<InitialSyncEventHandler> logger, IEventDispatcher dispatcher)
+        {
+            _logger = logger;
+            _dispatcher = dispatcher;
+        }
+
+        public async Task HandleAsync(InitialSync @event, CancellationToken cancellationToken)
+        {
+            _logger.LogInformation("Initial sync started for hub {HubKey}", @event.HubKey);
+
+            var companiesEvent = new CompaniesRequested { HubKey = @event.HubKey };
+            await _dispatcher.DispatchAsync(companiesEvent, cancellationToken);
+        }
+    }
+}

--- a/tests/LexosHub.ERP.VarejoOnline.Domain.Tests/Messaging/CompaniesRequestedEventHandlerTests.cs
+++ b/tests/LexosHub.ERP.VarejoOnline.Domain.Tests/Messaging/CompaniesRequestedEventHandlerTests.cs
@@ -17,9 +17,10 @@ namespace LexosHub.ERP.VarejoOnline.Domain.Tests.Messaging
         private readonly Mock<ILogger<CompaniesRequestedEventHandler>> _logger = new();
         private readonly Mock<IIntegrationService> _integrationService = new();
         private readonly Mock<IVarejoOnlineApiService> _apiService = new();
+        private readonly Mock<IEventDispatcher> _dispatcher = new();
 
         private CompaniesRequestedEventHandler CreateHandler() =>
-            new CompaniesRequestedEventHandler(_logger.Object, _integrationService.Object, _apiService.Object);
+            new CompaniesRequestedEventHandler(_logger.Object, _integrationService.Object, _apiService.Object, _dispatcher.Object);
 
         [Fact]
         public async Task HandleAsync_ShouldFetchIntegrationAndCallApiService()
@@ -49,6 +50,10 @@ namespace LexosHub.ERP.VarejoOnline.Domain.Tests.Messaging
                         r.Cnpj == evt.Cnpj
                     )
                 ), Times.Once);
+
+            _dispatcher.Verify(d => d.DispatchAsync(
+                    It.Is<ProductsRequested>(p => p.HubKey == evt.HubKey),
+                    It.IsAny<CancellationToken>()), Times.Once);
         }
     }
 }

--- a/tests/LexosHub.ERP.VarejoOnline.Domain.Tests/Messaging/InitialSyncEventHandlerTests.cs
+++ b/tests/LexosHub.ERP.VarejoOnline.Domain.Tests/Messaging/InitialSyncEventHandlerTests.cs
@@ -1,0 +1,32 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+using LexosHub.ERP.VarejoOnline.Infra.Messaging.Dispatcher;
+using LexosHub.ERP.VarejoOnline.Infra.Messaging.Events;
+using LexosHub.ERP.VarejoOnline.Infra.Messaging.Handlers;
+
+namespace LexosHub.ERP.VarejoOnline.Domain.Tests.Messaging
+{
+    public class InitialSyncEventHandlerTests
+    {
+        private readonly Mock<ILogger<InitialSyncEventHandler>> _logger = new();
+        private readonly Mock<IEventDispatcher> _dispatcher = new();
+
+        private InitialSyncEventHandler CreateHandler() =>
+            new InitialSyncEventHandler(_logger.Object, _dispatcher.Object);
+
+        [Fact]
+        public async Task HandleAsync_ShouldDispatchCompaniesRequested()
+        {
+            var evt = new InitialSync { HubKey = "key" };
+
+            await CreateHandler().HandleAsync(evt, CancellationToken.None);
+
+            _dispatcher.Verify(d => d.DispatchAsync(
+                    It.Is<CompaniesRequested>(c => c.HubKey == evt.HubKey),
+                    It.IsAny<CancellationToken>()), Times.Once);
+        }
+    }
+}

--- a/tests/LexosHub.ERP.VarejoOnline.Domain.Tests/Messaging/IntegrationCreatedEventHandlerTests.cs
+++ b/tests/LexosHub.ERP.VarejoOnline.Domain.Tests/Messaging/IntegrationCreatedEventHandlerTests.cs
@@ -14,9 +14,10 @@ namespace LexosHub.ERP.VarejoOnline.Domain.Tests.Messaging
     {
         private readonly Mock<ILogger<IntegrationCreatedEventHandler>> _logger = new();
         private readonly Mock<IIntegrationService> _integrationService = new();
+        private readonly Mock<IEventDispatcher> _dispatcher = new();
 
         private IntegrationCreatedEventHandler CreateHandler()
-            => new IntegrationCreatedEventHandler(_logger.Object, _integrationService.Object);
+            => new IntegrationCreatedEventHandler(_logger.Object, _integrationService.Object, _dispatcher.Object);
 
         [Fact]
         public async Task HandleAsync_ShouldCallAddOrUpdateIntegration()
@@ -40,6 +41,10 @@ namespace LexosHub.ERP.VarejoOnline.Domain.Tests.Messaging
                     d.Habilitado &&
                     d.Excluido == false
                 )), Times.Once);
+
+            _dispatcher.Verify(d => d.DispatchAsync(
+                    It.Is<InitialSync>(i => i.HubKey == evt.HubKey),
+                    It.IsAny<CancellationToken>()), Times.Once);
         }
     }
 }


### PR DESCRIPTION
## Summary
- handle InitialSync events
- link IntegrationCreated events to InitialSync
- request products after companies
- register new handlers
- test event flow

## Testing
- `dotnet test --no-build -c Release` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686d21dc12c88328921b498c66b1783a