### PR TITLE
Add ProdutoView mapper and tests

### DIFF
--- a/src/LexosHub.ERP.VarejoOnline.Infra.Messaging/Mappers/ProdutoViewMapper.cs
+++ b/src/LexosHub.ERP.VarejoOnline.Infra.Messaging/Mappers/ProdutoViewMapper.cs
@@ -1,0 +1,33 @@
+using System.Collections.Generic;
+using System.Linq;
+using LexosHub.ERP.VarejoOnline.Infra.VarejoOnlineApi.Responses;
+using ProdutoView = Lexos.Hub.Sync.Models.Produto.VarejoOnlineProduto;
+
+namespace LexosHub.ERP.VarejoOnline.Infra.Messaging.Mappers
+{
+    public static class ProdutoViewMapper
+    {
+        public static ProdutoView? Map(ProdutoResponse? source)
+        {
+            return source == null ? null : new ProdutoView
+            {
+                ProdutoIdGlobal = source.Id,
+                Nome = source.Descricao,
+                DescricaoResumida = source.DescricaoSimplificada,
+                Ean = source.CodigoBarras,
+                Peso = source.Peso,
+                Comprimento = source.Comprimento,
+                Largura = source.Largura,
+                Altura = source.Altura
+            };
+        }
+
+        public static List<ProdutoView> Map(IEnumerable<ProdutoResponse>? source)
+        {
+            return source?.Select(Map)
+                .Where(v => v != null)
+                .Cast<ProdutoView>()
+                .ToList() ?? new List<ProdutoView>();
+        }
+    }
+}

--- a/tests/LexosHub.ERP.VarejoOnline.Domain.Tests/Mappers/ProdutoViewMapperTests.cs
+++ b/tests/LexosHub.ERP.VarejoOnline.Domain.Tests/Mappers/ProdutoViewMapperTests.cs
@@ -1,0 +1,50 @@
+using System.Collections.Generic;
+using Lexos.Hub.Sync.Models.Produto;
+using LexosHub.ERP.VarejoOnline.Infra.Messaging.Mappers;
+using LexosHub.ERP.VarejoOnline.Infra.VarejoOnlineApi.Responses;
+using Xunit;
+
+namespace LexosHub.ERP.VarejoOnline.Domain.Tests.Mappers
+{
+    public class ProdutoViewMapperTests
+    {
+        [Fact]
+        public void Map_ShouldReturnNull_WhenSourceIsNull()
+        {
+            var result = ProdutoViewMapper.Map((ProdutoResponse?)null);
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void MapList_ShouldMapFields()
+        {
+            var source = new List<ProdutoResponse>
+            {
+                new ProdutoResponse
+                {
+                    Id = 5,
+                    Descricao = "Produto",
+                    DescricaoSimplificada = "Prod",
+                    CodigoBarras = "111",
+                    Peso = 1.1m,
+                    Comprimento = 2.2m,
+                    Largura = 3.3m,
+                    Altura = 4.4m
+                }
+            };
+
+            var result = ProdutoViewMapper.Map(source);
+
+            Assert.Single(result);
+            var item = result[0];
+            Assert.Equal(5, item.ProdutoIdGlobal);
+            Assert.Equal("Produto", item.Nome);
+            Assert.Equal("Prod", item.DescricaoResumida);
+            Assert.Equal("111", item.Ean);
+            Assert.Equal(1.1m, item.Peso);
+            Assert.Equal(2.2m, item.Comprimento);
+            Assert.Equal(3.3m, item.Largura);
+            Assert.Equal(4.4m, item.Altura);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- map ProdutoResponse to ProdutoView using new mapper
- verify ProdutoViewMapper with unit tests

## Testing
- `dotnet test --no-build --verbosity minimal` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d624ee04c83288c47bf802c65f03c