### PR TITLE
Add Pedido webhook service and endpoint

### DIFF
--- a/src/LexosHub.ERP.VarejoOnline.Api/Controllers/Pedido/PedidoController.cs
+++ b/src/LexosHub.ERP.VarejoOnline.Api/Controllers/Pedido/PedidoController.cs
@@ -1,12 +1,29 @@
-﻿using Microsoft.AspNetCore.Mvc;
+using LexosHub.ERP.VarejoOnline.Domain.DTOs.Pedido;
+using LexosHub.ERP.VarejoOnline.Domain.Interfaces.Services;
+using Microsoft.AspNetCore.Mvc;
 
 namespace LexosHub.ERP.VarejoOnline.Api.Controllers.Pedido
 {
+    [Produces("application/json")]
+    [Route("api/pedido")]
+    [ApiController]
     public class PedidoController : Controller
     {
-        public IActionResult Index()
+        private readonly IPedidoService _pedidoService;
+
+        public PedidoController(IPedidoService pedidoService)
         {
-            return View();
+            _pedidoService = pedidoService;
+        }
+
+        [HttpPost("webhook")]
+        public async Task<IActionResult> Webhook([FromBody] PedidoWebhookDto pedidoDto)
+        {
+            if (pedidoDto == null)
+                return BadRequest();
+
+            await _pedidoService.ProcessWebhookAsync(pedidoDto);
+            return Ok();
         }
     }
 }

--- a/src/LexosHub.ERP.VarejoOnline.Api/Program.cs
+++ b/src/LexosHub.ERP.VarejoOnline.Api/Program.cs
@@ -46,6 +46,7 @@ try
 
     builder.Services.AddTransient<IIntegrationService, IntegrationService>();
     builder.Services.AddTransient<IAuthService, AuthService>();
+    builder.Services.AddTransient<IPedidoService, PedidoService>();
     builder.Services.AddTransient<IVarejoOnlineApiService, VarejoOnlineApiService>();
     builder.Services.AddTransient<ISqsRepository, SqsRepository>();
 

--- a/src/LexosHub.ERP.VarejoOnline.Domain/DTOs/Pedido/PedidoWebhookDto.cs
+++ b/src/LexosHub.ERP.VarejoOnline.Domain/DTOs/Pedido/PedidoWebhookDto.cs
@@ -1,0 +1,10 @@
+using LexosHub.ERP.VarejoOnline.Infra.VarejoOnlineApi.Responses;
+
+namespace LexosHub.ERP.VarejoOnline.Domain.DTOs.Pedido
+{
+    public class PedidoWebhookDto
+    {
+        public string HubKey { get; set; } = string.Empty;
+        public List<ProdutoResponse>? Produtos { get; set; }
+    }
+}

--- a/src/LexosHub.ERP.VarejoOnline.Domain/Interfaces/Services/IPedidoService.cs
+++ b/src/LexosHub.ERP.VarejoOnline.Domain/Interfaces/Services/IPedidoService.cs
@@ -1,0 +1,9 @@
+using LexosHub.ERP.VarejoOnline.Domain.DTOs.Pedido;
+
+namespace LexosHub.ERP.VarejoOnline.Domain.Interfaces.Services
+{
+    public interface IPedidoService
+    {
+        Task ProcessWebhookAsync(PedidoWebhookDto pedido, CancellationToken cancellationToken = default);
+    }
+}

--- a/src/LexosHub.ERP.VarejoOnline.Domain/Services/PedidoService.cs
+++ b/src/LexosHub.ERP.VarejoOnline.Domain/Services/PedidoService.cs
@@ -1,6 +1,39 @@
-﻿namespace LexosHub.ERP.VarejoOnline.Domain.Services
+using LexosHub.ERP.VarejoOnline.Domain.DTOs.Pedido;
+using LexosHub.ERP.VarejoOnline.Domain.Interfaces.Services;
+using LexosHub.ERP.VarejoOnline.Infra.Messaging.Dispatcher;
+using LexosHub.ERP.VarejoOnline.Infra.Messaging.Events;
+using Microsoft.Extensions.Logging;
+
+namespace LexosHub.ERP.VarejoOnline.Domain.Services
 {
-    internal class PedidoService
+    public class PedidoService : IPedidoService
     {
+        private readonly ILogger<PedidoService> _logger;
+        private readonly IEventDispatcher _dispatcher;
+
+        public PedidoService(ILogger<PedidoService> logger, IEventDispatcher dispatcher)
+        {
+            _logger = logger;
+            _dispatcher = dispatcher;
+        }
+
+        public async Task ProcessWebhookAsync(PedidoWebhookDto pedido, CancellationToken cancellationToken = default)
+        {
+            if (pedido == null)
+                throw new ArgumentNullException(nameof(pedido));
+
+            _logger.LogInformation("Pedido recebido para o hub {HubKey} com {Count} produtos", pedido.HubKey, pedido.Produtos?.Count ?? 0);
+
+            var evt = new ProductsPageProcessed
+            {
+                HubKey = pedido.HubKey,
+                Start = 0,
+                PageSize = pedido.Produtos?.Count ?? 0,
+                ProcessedCount = pedido.Produtos?.Count ?? 0,
+                Produtos = pedido.Produtos
+            };
+
+            await _dispatcher.DispatchAsync(evt, cancellationToken);
+        }
     }
 }

--- a/tests/LexosHub.ERP.VarejoOnline.Domain.Tests/Services/PedidoServiceTests.cs
+++ b/tests/LexosHub.ERP.VarejoOnline.Domain.Tests/Services/PedidoServiceTests.cs
@@ -1,0 +1,39 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using LexosHub.ERP.VarejoOnline.Domain.DTOs.Pedido;
+using LexosHub.ERP.VarejoOnline.Domain.Services;
+using LexosHub.ERP.VarejoOnline.Infra.Messaging.Dispatcher;
+using LexosHub.ERP.VarejoOnline.Infra.Messaging.Events;
+using LexosHub.ERP.VarejoOnline.Infra.VarejoOnlineApi.Responses;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace LexosHub.ERP.VarejoOnline.Domain.Tests.Services
+{
+    public class PedidoServiceTests
+    {
+        private readonly Mock<ILogger<PedidoService>> _logger = new();
+        private readonly Mock<IEventDispatcher> _dispatcher = new();
+
+        private PedidoService CreateService() => new PedidoService(_logger.Object, _dispatcher.Object);
+
+        [Fact]
+        public async Task ProcessWebhookAsync_ShouldDispatchEvent()
+        {
+            var dto = new PedidoWebhookDto
+            {
+                HubKey = "key",
+                Produtos = new List<ProdutoResponse> { new() }
+            };
+
+            await CreateService().ProcessWebhookAsync(dto, CancellationToken.None);
+
+            _dispatcher.Verify(d => d.DispatchAsync(
+                    It.Is<ProductsPageProcessed>(p => p.HubKey == "key" && p.ProcessedCount == 1),
+                    It.IsAny<CancellationToken>()),
+                Times.Once);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `IPedidoService` interface and DTO for webhook payload
- implement `PedidoService` to dispatch ProductsPageProcessed events
- expose webhook endpoint in `PedidoController`
- register `PedidoService` in DI container
- test service dispatch logic

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68766c7f27b88328bac4a2cd0440463d