### PR TITLE
Fix webhook registration method

### DIFF
--- a/src/LexosHub.ERP.VarejoOnline.Infra.CrossCutting/Default/Response.cs
+++ b/src/LexosHub.ERP.VarejoOnline.Infra.CrossCutting/Default/Response.cs
@@ -4,6 +4,7 @@
     {
         public TResponse? Result { get; set; }
         public ErrorResult? Error { get; set; }
+        public System.Net.HttpStatusCode StatusCode { get; set; }
         public bool IsSuccess
         {
             get

--- a/src/LexosHub.ERP.VarejoOnline.Infra.ErpApi/Responses/Webhook/WebhookOperationResponse.cs
+++ b/src/LexosHub.ERP.VarejoOnline.Infra.ErpApi/Responses/Webhook/WebhookOperationResponse.cs
@@ -1,0 +1,9 @@
+namespace LexosHub.ERP.VarejoOnline.Infra.ErpApi.Responses.Webhook
+{
+    public sealed class WebhookOperationResponse
+    {
+        public string? IdRecurso { get; set; }
+        public int CodigoMensagem { get; set; }
+        public string? Mensagem { get; set; }
+    }
+}


### PR DESCRIPTION
## Summary
- implement `WebhookOperationResponse` model for webhook results
- extend `Response<T>` with `StatusCode`
- call common `ExecuteAsync` in webhook registration method

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68767fb1213c8328ac97d6b5a2d3f07b