### PR TITLE
Add webhook product notification handling

### DIFF
--- a/src/LexosHub.ERP.VarejoOnline.Api/Controllers/Webhook/WebhookController.cs
+++ b/src/LexosHub.ERP.VarejoOnline.Api/Controllers/Webhook/WebhookController.cs
@@ -1,6 +1,9 @@
 using LexosHub.ERP.VarejoOnline.Domain.DTOs.Produto;
 using LexosHub.ERP.VarejoOnline.Domain.Interfaces.Services;
 using LexosHub.ERP.VarejoOnline.Infra.ErpApi.Request;
+using LexosHub.ERP.VarejoOnline.Infra.Messaging.Dispatcher;
+using LexosHub.ERP.VarejoOnline.Infra.Messaging.Events;
+using Microsoft.Extensions.Logging;
 using Microsoft.AspNetCore.Mvc;
 
 namespace LexosHub.ERP.VarejoOnline.Api.Controllers.Webhook
@@ -11,10 +14,17 @@ namespace LexosHub.ERP.VarejoOnline.Api.Controllers.Webhook
     public class WebhookController : Controller
     {
         private readonly IVarejoOnlineApiService _varejoOnlineApiService;
+        private readonly IEventDispatcher _dispatcher;
+        private readonly ILogger<WebhookController> _logger;
 
-        public WebhookController(IVarejoOnlineApiService varejoOnlineApiService)
+        public WebhookController(
+            IVarejoOnlineApiService varejoOnlineApiService,
+            IEventDispatcher dispatcher,
+            ILogger<WebhookController> logger)
         {
             _varejoOnlineApiService = varejoOnlineApiService;
+            _dispatcher = dispatcher;
+            _logger = logger;
         }
 
         [HttpPost("webhook/produto")]
@@ -24,6 +34,37 @@ namespace LexosHub.ERP.VarejoOnline.Api.Controllers.Webhook
                 return BadRequest();
 
             await _varejoOnlineApiService.RegisterWebhookAsync(produtoDto);
+            return Ok();
+        }
+
+        [HttpPost("webhook/produtos")]
+        public async Task<IActionResult> Produtos([FromBody] WebhookNotificationDto notification, CancellationToken cancellationToken)
+        {
+            if (notification == null)
+                return BadRequest();
+
+            _logger.LogInformation("Webhook payload received: {@payload}", notification);
+
+            long? productId = null;
+            if (!string.IsNullOrWhiteSpace(notification.Object))
+            {
+                var lastSegment = notification.Object.TrimEnd('/')
+                    .Split('/', StringSplitOptions.RemoveEmptyEntries)
+                    .LastOrDefault();
+                if (long.TryParse(lastSegment, out var parsed))
+                    productId = parsed;
+            }
+
+            var evt = new ProductsRequested
+            {
+                HubKey = notification.ContractId ?? string.Empty,
+                Id = productId
+            };
+
+            await _dispatcher.DispatchAsync(evt, cancellationToken);
+
+            _logger.LogInformation("Dispatched ProductsRequested event for product {ProductId}", productId);
+
             return Ok();
         }
     }

--- a/src/LexosHub.ERP.VarejoOnline.Domain/DTOs/Produto/WebhookNotificationDto.cs
+++ b/src/LexosHub.ERP.VarejoOnline.Domain/DTOs/Produto/WebhookNotificationDto.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace LexosHub.ERP.VarejoOnline.Domain.DTOs.Produto
+{
+    public class WebhookNotificationDto
+    {
+        public string Object { get; set; } = string.Empty;
+        public string WebhookEvent { get; set; } = string.Empty;
+        public string EventType { get; set; } = string.Empty;
+        public string? ContractId { get; set; }
+    }
+}


### PR DESCRIPTION
## Summary
- create `WebhookNotificationDto` to represent webhook notifications
- inject `ILogger` and `IEventDispatcher` into `WebhookController`
- handle `POST api/produto/webhook/produtos` for product notifications

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6876a0a944fc83289882807be6b75dfd