### PR TITLE
Add price tables processed event and handler

### DIFF
--- a/src/LexosHub.ERP.VarejoOnline.Api/Program.cs
+++ b/src/LexosHub.ERP.VarejoOnline.Api/Program.cs
@@ -75,6 +75,7 @@ try
     builder.Services.AddTransient<IEventHandler<InitialSync>, InitialSyncEventHandler>();
     builder.Services.AddTransient<IEventHandler<ProductsRequested>, ProductsRequestedEventHandler>();
     builder.Services.AddTransient<IEventHandler<ProductsPageProcessed>, ProductsPageProcessedEventHandler>();
+    builder.Services.AddTransient<IEventHandler<PriceTablesPageProcessed>, PriceTablesPageProcessedEventHandler>();
     builder.Services.AddTransient<IEventHandler<CompaniesRequested>, CompaniesRequestedEventHandler>();
     builder.Services.AddHostedService<SqsListenerService>();
 

--- a/src/LexosHub.ERP.VarejoOnline.Infra.Messaging/Events/PriceTablesPageProcessed.cs
+++ b/src/LexosHub.ERP.VarejoOnline.Infra.Messaging/Events/PriceTablesPageProcessed.cs
@@ -1,0 +1,13 @@
+using LexosHub.ERP.VarejoOnline.Infra.ErpApi.Responses.Prices;
+
+namespace LexosHub.ERP.VarejoOnline.Infra.Messaging.Events
+{
+    public class PriceTablesPageProcessed : BaseEvent
+    {
+        public string HubKey { get; set; } = null!;
+        public int Start { get; set; }
+        public int PageSize { get; set; }
+        public int ProcessedCount { get; set; }
+        public List<TabelaPrecoListResponse>? PriceTables { get; set; }
+    }
+}

--- a/src/LexosHub.ERP.VarejoOnline.Infra.Messaging/Handlers/PriceTablesPageProcessedEventHandler.cs
+++ b/src/LexosHub.ERP.VarejoOnline.Infra.Messaging/Handlers/PriceTablesPageProcessedEventHandler.cs
@@ -1,0 +1,56 @@
+using Lexos.Hub.Sync;
+using Lexos.Hub.Sync.Enums;
+using Lexos.SQS.Interface;
+using LexosHub.ERP.VarejoOnline.Infra.CrossCutting.Settings;
+using LexosHub.ERP.VarejoOnline.Infra.Messaging.Events;
+using LexosHub.ERP.VarejoOnline.Infra.Messaging.Mappers.Preco;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Newtonsoft.Json;
+
+namespace LexosHub.ERP.VarejoOnline.Infra.Messaging.Handlers
+{
+    public class PriceTablesPageProcessedEventHandler : IEventHandler<PriceTablesPageProcessed>
+    {
+        private readonly ILogger<PriceTablesPageProcessedEventHandler> _logger;
+        private readonly ISqsRepository _syncOutSqsRepository;
+
+        public PriceTablesPageProcessedEventHandler(ILogger<PriceTablesPageProcessedEventHandler> logger, ISqsRepository syncOutSqsRepository, IOptions<SyncOutConfig> syncOutSqsConfig)
+        {
+            _logger = logger;
+            _syncOutSqsRepository = syncOutSqsRepository;
+            var syncOutConfig = syncOutSqsConfig.Value;
+            _syncOutSqsRepository.IniciarFila($"{syncOutConfig.SQSBaseUrl}{syncOutConfig.SQSAccessKeyId}/{syncOutConfig.SQSName}");
+        }
+
+        public Task HandleAsync(PriceTablesPageProcessed @event, CancellationToken cancellationToken)
+        {
+            _logger.LogInformation(
+                "Página de tabelas de preço processada. Hub: {HubKey}, Início: {Start}, Quantidade: {PageSize}, Processados: {ProcessedCount}, Tabelas: {PriceTableCount}",
+                @event.HubKey,
+                @event.Start,
+                @event.PageSize,
+                @event.ProcessedCount,
+                @event.PriceTables?.Count ?? 0);
+
+            if (@event.PriceTables is not null && @event.PriceTables.Any())
+            {
+                var mapped = @event.PriceTables.Map();
+
+                if (mapped is not null)
+                {
+                    var notificacao = new NotificacaoAtualizacaoModel()
+                    {
+                        Chave = @event.HubKey,
+                        DataHora = DateTime.Now,
+                        Json = JsonConvert.SerializeObject(mapped),
+                        TipoProcesso = TipoProcessoAtualizacao.Preco,
+                        PlataformaId = 41
+                    };
+                    _syncOutSqsRepository.AdicionarMensagemFilaFifo(notificacao, $"notificacao-syncout-{notificacao.Chave}");
+                }
+            }
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/LexosHub.ERP.VarejoOnline.Infra.Messaging/Mappers/Preco/TabelaPrecoMapper.cs
+++ b/src/LexosHub.ERP.VarejoOnline.Infra.Messaging/Mappers/Preco/TabelaPrecoMapper.cs
@@ -1,0 +1,36 @@
+using Lexos.Hub.Sync.Models.Produto;
+using LexosHub.ERP.VarejoOnline.Infra.ErpApi.Responses.Prices;
+
+namespace LexosHub.ERP.VarejoOnline.Infra.Messaging.Mappers.Preco
+{
+    public static class TabelaPrecoMapper
+    {
+        private const string CodigoProdutoPrefixoPrecoRegiao = "preco_regiao_";
+
+        public static ProdutoPrecoView? Map(this TabelaPrecoListResponse? source)
+        {
+            if (source == null)
+                return null;
+
+            return new ProdutoPrecoView
+            {
+                ProdutoId = source.Id,
+                ProdutoIdGlobal = source.Id,
+                Codigo = $"{CodigoProdutoPrefixoPrecoRegiao}{source.Id}",
+                Descricao = source.Name ?? string.Empty,
+                Preco = 0,
+                Tipo = Lexos.Hub.Sync.Constantes.Produto.SIMPLES,
+                Sku = string.Empty,
+                Quantidade = 0
+            };
+        }
+
+        public static List<ProdutoPrecoView> Map(this List<TabelaPrecoListResponse>? source)
+        {
+            return source?.Select(Map)
+                .Where(v => v != null)
+                .Cast<ProdutoPrecoView>()
+                .ToList() ?? new List<ProdutoPrecoView>();
+        }
+    }
+}

--- a/src/LexosHub.ERP.VarejoOnline.Infra.Messaging/Resolver/EntityTypeResolver.cs
+++ b/src/LexosHub.ERP.VarejoOnline.Infra.Messaging/Resolver/EntityTypeResolver.cs
@@ -11,6 +11,7 @@ namespace LexosHub.ERP.VarejoOnline.Infra.Messaging.Dispatcher
             { "IntegrationCreated", typeof(IntegrationCreated) },
             { "ProductsRequested", typeof(ProductsRequested) },
             { "ProductsPageProcessed", typeof(ProductsPageProcessed) },
+            { "PriceTablesPageProcessed", typeof(PriceTablesPageProcessed) },
             { "CompaniesRequested", typeof(CompaniesRequested) },
             { "InitialSync", typeof(InitialSync) }
         };

--- a/tests/LexosHub.ERP.VarejoOnline.Domain.Tests/Messaging/EventTypeTests.cs
+++ b/tests/LexosHub.ERP.VarejoOnline.Domain.Tests/Messaging/EventTypeTests.cs
@@ -15,6 +15,7 @@ namespace LexosHub.ERP.VarejoOnline.Domain.Tests.Messaging
             new object[] { new CompaniesRequested() },
             new object[] { new ProductsRequested() },
             new object[] { new ProductsPageProcessed() },
+            new object[] { new PriceTablesPageProcessed() },
             new object[] { new InitialSync() }
         };
 

--- a/tests/LexosHub.ERP.VarejoOnline.Domain.Tests/Messaging/PriceTablesPageProcessedEventHandlerTests.cs
+++ b/tests/LexosHub.ERP.VarejoOnline.Domain.Tests/Messaging/PriceTablesPageProcessedEventHandlerTests.cs
@@ -1,0 +1,52 @@
+using Lexos.SQS.Interface;
+using LexosHub.ERP.VarejoOnline.Domain.Interfaces.Repositories.Integration;
+using LexosHub.ERP.VarejoOnline.Infra.CrossCutting.Settings;
+using LexosHub.ERP.VarejoOnline.Infra.Messaging.Events;
+using LexosHub.ERP.VarejoOnline.Infra.Messaging.Handlers;
+using LexosHub.ERP.VarejoOnline.Infra.ErpApi.Responses.Prices;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace LexosHub.ERP.VarejoOnline.Domain.Tests.Messaging
+{
+    public class PriceTablesPageProcessedEventHandlerTests
+    {
+        private readonly Mock<ILogger<PriceTablesPageProcessedEventHandler>> _logger = new();
+        private readonly Mock<ISqsRepository> _sqsRepository = new();
+        private readonly Mock<IIntegrationRepository> _integrationRepository = new();
+        private readonly Mock<IOptions<SyncOutConfig>> _syncOutSqsConfigMock = new();
+
+        private PriceTablesPageProcessedEventHandler CreateHandler() =>
+            new PriceTablesPageProcessedEventHandler(_logger.Object, _sqsRepository.Object, _syncOutSqsConfigMock.Object);
+
+        [Fact]
+        public async Task HandleAsync_ShouldLogInformation()
+        {
+            var evt = new PriceTablesPageProcessed
+            {
+                HubKey = "key",
+                Start = 1,
+                PageSize = 2,
+                ProcessedCount = 2,
+                PriceTables = new List<TabelaPrecoListResponse> { new(), new() }
+            };
+
+            await CreateHandler().HandleAsync(evt, CancellationToken.None);
+
+            _logger.Verify(
+                x => x.Log(
+                    LogLevel.Information,
+                    It.IsAny<EventId>(),
+                    It.Is<It.IsAnyType>((v, t) => v.ToString().Contains("key")),
+                    It.IsAny<Exception>(),
+                    It.IsAny<Func<It.IsAnyType, Exception, string>>()),
+                Times.Once);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- introduce `PriceTablesPageProcessed` event and map through event resolver
- add `PriceTablesPageProcessedEventHandler` and mapper for price tables
- register the new handler
- extend event type tests
- create tests for price tables processed handler

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68783a3feb448328b88649192b2b9962