### PR TITLE
Add PriceTableMapper and unit tests

### DIFF
--- a/src/LexosHub.ERP.VarejoOnline.Infra.Messaging/Handlers/PriceTablesPageProcessedEventHandler.cs
+++ b/src/LexosHub.ERP.VarejoOnline.Infra.Messaging/Handlers/PriceTablesPageProcessedEventHandler.cs
@@ -3,7 +3,7 @@ using Lexos.Hub.Sync.Enums;
 using Lexos.SQS.Interface;
 using LexosHub.ERP.VarejoOnline.Infra.CrossCutting.Settings;
 using LexosHub.ERP.VarejoOnline.Infra.Messaging.Events;
-using LexosHub.ERP.VarejoOnline.Infra.Messaging.Mappers.Preco;
+using LexosHub.ERP.VarejoOnline.Infra.Messaging.Mappers;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Newtonsoft.Json;

--- a/src/LexosHub.ERP.VarejoOnline.Infra.Messaging/Mappers/PriceTableMapper.cs
+++ b/src/LexosHub.ERP.VarejoOnline.Infra.Messaging/Mappers/PriceTableMapper.cs
@@ -1,0 +1,35 @@
+using Lexos.Hub.Sync.Models.Produto;
+using LexosHub.ERP.VarejoOnline.Infra.ErpApi.Responses.Prices;
+
+namespace LexosHub.ERP.VarejoOnline.Infra.Messaging.Mappers
+{
+    public static class PriceTableMapper
+    {
+        public static ProdutoPrecoView? Map(this TabelaPrecoListResponse? source)
+        {
+            if (source == null)
+                return null;
+
+            return new ProdutoPrecoView
+            {
+                ProdutoId = source.Id,
+                ProdutoIdGlobal = source.Id,
+                Codigo = source.Id.ToString(),
+                Descricao = source.Name ?? string.Empty,
+                Preco = 0,
+                Tipo = Lexos.Hub.Sync.Constantes.Produto.SIMPLES,
+                Sku = string.Empty,
+                Quantidade = 0,
+                TipoPrecoId = source.Id
+            };
+        }
+
+        public static List<ProdutoPrecoView> Map(this List<TabelaPrecoListResponse>? source)
+        {
+            return source?.Select(Map)
+                .Where(v => v != null)
+                .Cast<ProdutoPrecoView>()
+                .ToList() ?? new List<ProdutoPrecoView>();
+        }
+    }
+}

--- a/tests/LexosHub.ERP.VarejoOnline.Domain.Tests/Mappers/PriceTableMapperTests.cs
+++ b/tests/LexosHub.ERP.VarejoOnline.Domain.Tests/Mappers/PriceTableMapperTests.cs
@@ -1,0 +1,42 @@
+using System.Collections.Generic;
+using Lexos.Hub.Sync.Models.Produto;
+using LexosHub.ERP.VarejoOnline.Infra.Messaging.Mappers;
+using LexosHub.ERP.VarejoOnline.Infra.ErpApi.Responses.Prices;
+using Xunit;
+
+namespace LexosHub.ERP.VarejoOnline.Domain.Tests.Mappers
+{
+    public class PriceTableMapperTests
+    {
+        [Fact]
+        public void Map_ShouldReturnNull_WhenSourceIsNull()
+        {
+            var result = PriceTableMapper.Map((TabelaPrecoListResponse?)null);
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void MapList_ShouldMapFields()
+        {
+            var source = new List<TabelaPrecoListResponse>
+            {
+                new TabelaPrecoListResponse
+                {
+                    Id = 1,
+                    Name = "Tabela",
+                    IsActive = true
+                }
+            };
+
+            var result = source.Map();
+
+            Assert.Single(result);
+            var item = result[0];
+            Assert.Equal(1, item.ProdutoId);
+            Assert.Equal(1, item.ProdutoIdGlobal);
+            Assert.Equal("1", item.Codigo);
+            Assert.Equal("Tabela", item.Descricao);
+            Assert.Equal(1, item.TipoPrecoId);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- map TabelaPrecoListResponse to ProdutoPrecoView using new PriceTableMapper
- update PriceTablesPageProcessedEventHandler to use the new mapper
- add unit tests for PriceTableMapper

## Testing
- `dotnet test tests/LexosHub.ERP.VarejoOnline.Domain.Tests/LexosHub.ERP.VarejoOnline.Domain.Tests.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68783e28c6e88328b9a7321df344b70d