### PR TITLE
Implement PriceTables page event handling

### DIFF
--- a/src/LexosHub.ERP.VarejoOnline.Api/Program.cs
+++ b/src/LexosHub.ERP.VarejoOnline.Api/Program.cs
@@ -76,6 +76,7 @@ try
     builder.Services.AddTransient<IEventHandler<ProductsRequested>, ProductsRequestedEventHandler>();
     builder.Services.AddTransient<IEventHandler<ProductsPageProcessed>, ProductsPageProcessedEventHandler>();
     builder.Services.AddTransient<IEventHandler<PriceTablesRequested>, PriceTablesRequestedEventHandler>();
+    builder.Services.AddTransient<IEventHandler<PriceTablesPageProcessed>, PriceTablesPageProcessedEventHandler>();
     builder.Services.AddTransient<IEventHandler<CompaniesRequested>, CompaniesRequestedEventHandler>();
     builder.Services.AddHostedService<SqsListenerService>();
 

--- a/src/LexosHub.ERP.VarejoOnline.Infra.Messaging/Events/PriceTablesPageProcessed.cs
+++ b/src/LexosHub.ERP.VarejoOnline.Infra.Messaging/Events/PriceTablesPageProcessed.cs
@@ -1,0 +1,13 @@
+using LexosHub.ERP.VarejoOnline.Infra.ErpApi.Responses.Prices;
+
+namespace LexosHub.ERP.VarejoOnline.Infra.Messaging.Events
+{
+    public class PriceTablesPageProcessed : BaseEvent
+    {
+        public string HubKey { get; set; } = null!;
+        public int Start { get; set; }
+        public int PageSize { get; set; }
+        public int ProcessedCount { get; set; }
+        public List<TabelaPrecoListResponse>? PriceTables { get; set; }
+    }
+}

--- a/src/LexosHub.ERP.VarejoOnline.Infra.Messaging/Handlers/PriceTablesPageProcessedEventHandler.cs
+++ b/src/LexosHub.ERP.VarejoOnline.Infra.Messaging/Handlers/PriceTablesPageProcessedEventHandler.cs
@@ -1,0 +1,59 @@
+using Lexos.Hub.Sync;
+using Lexos.Hub.Sync.Enums;
+using Lexos.SQS.Interface;
+using LexosHub.ERP.VarejoOnline.Infra.CrossCutting.Settings;
+using LexosHub.ERP.VarejoOnline.Infra.Messaging.Events;
+using LexosHub.ERP.VarejoOnline.Infra.Messaging.Mappers.Preco;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Newtonsoft.Json;
+
+namespace LexosHub.ERP.VarejoOnline.Infra.Messaging.Handlers
+{
+    public class PriceTablesPageProcessedEventHandler : IEventHandler<PriceTablesPageProcessed>
+    {
+        private readonly ILogger<PriceTablesPageProcessedEventHandler> _logger;
+        private readonly ISqsRepository _syncOutSqsRepository;
+
+        public PriceTablesPageProcessedEventHandler(
+            ILogger<PriceTablesPageProcessedEventHandler> logger,
+            ISqsRepository syncOutSqsRepository,
+            IOptions<SyncOutConfig> syncOutSqsConfig)
+        {
+            _logger = logger;
+            _syncOutSqsRepository = syncOutSqsRepository;
+            var syncOutConfig = syncOutSqsConfig.Value;
+            _syncOutSqsRepository.IniciarFila($"{syncOutConfig.SQSBaseUrl}{syncOutConfig.SQSAccessKeyId}/{syncOutConfig.SQSName}");
+        }
+
+        public Task HandleAsync(PriceTablesPageProcessed @event, CancellationToken cancellationToken)
+        {
+            _logger.LogInformation(
+                "Página de tabelas de preço processada. Hub: {HubKey}, Início: {Start}, Quantidade: {PageSize}, Processados: {ProcessedCount}, Tabelas: {PriceTableCount}",
+                @event.HubKey,
+                @event.Start,
+                @event.PageSize,
+                @event.ProcessedCount,
+                @event.PriceTables?.Count ?? 0);
+
+            if (@event != null && @event.PriceTables.Any())
+            {
+                var mapped = @event.PriceTables.Map();
+
+                if (mapped != null)
+                {
+                    var notificacao = new NotificacaoAtualizacaoModel
+                    {
+                        Chave = @event.HubKey,
+                        DataHora = DateTime.Now,
+                        Json = JsonConvert.SerializeObject(mapped),
+                        TipoProcesso = TipoProcessoAtualizacao.Produto,
+                        PlataformaId = 41
+                    };
+                    _syncOutSqsRepository.AdicionarMensagemFilaFifo(notificacao, $"notificacao-syncout-{notificacao.Chave}");
+                }
+            }
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/LexosHub.ERP.VarejoOnline.Infra.Messaging/Handlers/PriceTablesRequestedEventHandler.cs
+++ b/src/LexosHub.ERP.VarejoOnline.Infra.Messaging/Handlers/PriceTablesRequestedEventHandler.cs
@@ -67,7 +67,7 @@ namespace LexosHub.ERP.VarejoOnline.Infra.Messaging.Handlers
                     break;
                 }
 
-                var pageEvent = new PriceTablesRequested
+                var pageEvent = new PriceTablesPageProcessed
                 {
                     HubKey = @event.HubKey,
                     Start = start,

--- a/src/LexosHub.ERP.VarejoOnline.Infra.Messaging/Resolver/EntityTypeResolver.cs
+++ b/src/LexosHub.ERP.VarejoOnline.Infra.Messaging/Resolver/EntityTypeResolver.cs
@@ -12,6 +12,7 @@ namespace LexosHub.ERP.VarejoOnline.Infra.Messaging.Dispatcher
             { "ProductsRequested", typeof(ProductsRequested) },
             { "ProductsPageProcessed", typeof(ProductsPageProcessed) },
             { "PriceTablesRequested", typeof(PriceTablesRequested) },
+            { "PriceTablesPageProcessed", typeof(PriceTablesPageProcessed) },
             { "CompaniesRequested", typeof(CompaniesRequested) },
             { "InitialSync", typeof(InitialSync) }
         };

--- a/tests/LexosHub.ERP.VarejoOnline.Domain.Tests/Messaging/EventTypeTests.cs
+++ b/tests/LexosHub.ERP.VarejoOnline.Domain.Tests/Messaging/EventTypeTests.cs
@@ -16,6 +16,7 @@ namespace LexosHub.ERP.VarejoOnline.Domain.Tests.Messaging
             new object[] { new ProductsRequested() },
             new object[] { new ProductsPageProcessed() },
             new object[] { new PriceTablesRequested() },
+            new object[] { new PriceTablesPageProcessed() },
             new object[] { new InitialSync() }
         };
 

--- a/tests/LexosHub.ERP.VarejoOnline.Domain.Tests/Messaging/PriceTablesPageProcessedEventHandlerTests.cs
+++ b/tests/LexosHub.ERP.VarejoOnline.Domain.Tests/Messaging/PriceTablesPageProcessedEventHandlerTests.cs
@@ -1,5 +1,4 @@
 using Lexos.SQS.Interface;
-using LexosHub.ERP.VarejoOnline.Domain.Interfaces.Repositories.Integration;
 using LexosHub.ERP.VarejoOnline.Infra.CrossCutting.Settings;
 using LexosHub.ERP.VarejoOnline.Infra.Messaging.Events;
 using LexosHub.ERP.VarejoOnline.Infra.Messaging.Handlers;
@@ -12,30 +11,22 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
-using LexosHub.ERP.VarejoOnline.Domain.Interfaces.Services;
-using Microsoft.Extensions.Configuration;
-using LexosHub.ERP.VarejoOnline.Infra.Messaging.Dispatcher;
 
 namespace LexosHub.ERP.VarejoOnline.Domain.Tests.Messaging
 {
     public class PriceTablesPageProcessedEventHandlerTests
     {
-        private readonly Mock<ILogger<PriceTablesRequestedEventHandler>> _logger = new();
+        private readonly Mock<ILogger<PriceTablesPageProcessedEventHandler>> _logger = new();
         private readonly Mock<ISqsRepository> _sqsRepository = new();
-        private readonly Mock<IIntegrationRepository> _integrationRepository = new();
         private readonly Mock<IOptions<SyncOutConfig>> _syncOutSqsConfigMock = new();
-        private readonly Mock<IVarejoOnlineApiService> _varejoOnlineApiService = new();
-        private readonly Mock<IIntegrationService> _integrationService = new();
-        private readonly Mock<IEventDispatcher> _dispatcher = new();
-        private readonly Mock<IConfiguration> _configuration = new();
 
-        private PriceTablesRequestedEventHandler CreateHandler() =>
-            new PriceTablesRequestedEventHandler(_logger.Object, _sqsRepository.Object, _syncOutSqsConfigMock.Object, _varejoOnlineApiService.Object, _integrationService.Object, _configuration.Object, _dispatcher.Object);
+        private PriceTablesPageProcessedEventHandler CreateHandler() =>
+            new PriceTablesPageProcessedEventHandler(_logger.Object, _sqsRepository.Object, _syncOutSqsConfigMock.Object);
 
         [Fact]
         public async Task HandleAsync_ShouldLogInformation()
         {
-            var evt = new PriceTablesRequested
+            var evt = new PriceTablesPageProcessed
             {
                 HubKey = "key",
                 Start = 1,


### PR DESCRIPTION
## Summary
- create `PriceTablesPageProcessed` event and corresponding handler
- dispatch `PriceTablesPageProcessed` from `PriceTablesRequestedEventHandler`
- register the new handler in the API
- map `PriceTablesPageProcessed` in `EventTypeResolver`
- adjust tests for event and handler

## Testing
- `dotnet test` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878e10b5a108328877d7dde71b87da0