### PR TITLE
Refactor webhook registration logic

### DIFF
--- a/src/LexosHub.ERP.VarejoOnline.Domain/Interfaces/Services/IWebhookService.cs
+++ b/src/LexosHub.ERP.VarejoOnline.Domain/Interfaces/Services/IWebhookService.cs
@@ -1,10 +1,13 @@
 using LexosHub.ERP.VarejoOnline.Domain.DTOs.Webhook;
+using LexosHub.ERP.VarejoOnline.Domain.DTOs.Produto;
 using LexosHub.ERP.VarejoOnline.Infra.CrossCutting.Default;
+using System.Threading;
 
 namespace LexosHub.ERP.VarejoOnline.Domain.Interfaces.Services
 {
     public interface IWebhookService
     {
         Task<Response<WebhookRecordDto>> AddAsync(WebhookRecordDto webhook);
+        Task<Response<WebhookRecordDto>> RegisterAsync(WebhookDto webhookDto, CancellationToken cancellationToken = default);
     }
 }

--- a/src/LexosHub.ERP.VarejoOnline.Domain/Services/WebhookService.cs
+++ b/src/LexosHub.ERP.VarejoOnline.Domain/Services/WebhookService.cs
@@ -1,23 +1,74 @@
 using LexosHub.ERP.VarejoOnline.Domain.DTOs.Webhook;
+using LexosHub.ERP.VarejoOnline.Domain.DTOs.Produto;
+using LexosHub.ERP.VarejoOnline.Infra.ErpApi.Request;
+using LexosHub.ERP.VarejoOnline.Infra.ErpApi.Responses.Webhook;
 using LexosHub.ERP.VarejoOnline.Domain.Interfaces.Repositories.Webhook;
 using LexosHub.ERP.VarejoOnline.Domain.Interfaces.Services;
 using LexosHub.ERP.VarejoOnline.Infra.CrossCutting.Default;
+using System.Threading;
+using System.Collections.Generic;
+using System;
 
 namespace LexosHub.ERP.VarejoOnline.Domain.Services
 {
     public class WebhookService : IWebhookService
     {
         private readonly IWebhookRepository _webhookRepository;
+        private readonly IIntegrationService _integrationService;
+        private readonly IVarejoOnlineApiService _apiService;
 
-        public WebhookService(IWebhookRepository webhookRepository)
+        public WebhookService(
+            IWebhookRepository webhookRepository,
+            IIntegrationService integrationService,
+            IVarejoOnlineApiService apiService)
         {
             _webhookRepository = webhookRepository;
+            _integrationService = integrationService;
+            _apiService = apiService;
         }
 
         public async Task<Response<WebhookRecordDto>> AddAsync(WebhookRecordDto webhook)
         {
             var result = await _webhookRepository.AddAsync(webhook);
             return new Response<WebhookRecordDto>(result);
+        }
+
+        public async Task<Response<WebhookRecordDto>> RegisterAsync(WebhookDto webhookDto, CancellationToken cancellationToken = default)
+        {
+            if (webhookDto == null)
+                throw new ArgumentNullException(nameof(webhookDto));
+
+            var integrationResponse = await _integrationService.GetIntegrationByKeyAsync(webhookDto.HubKey);
+
+            if (integrationResponse.Result == null)
+                return new Response<WebhookRecordDto> { Error = new ErrorResult("integrationNotFound") };
+
+            var token = integrationResponse.Result.Token ?? string.Empty;
+
+            var request = new WebhookRequest
+            {
+                Event = webhookDto.Event,
+                url = webhookDto.Url,
+                types = new List<string> { webhookDto.Method }
+            };
+
+            var result = await _apiService.RegisterWebhookAsync(token, request, cancellationToken);
+
+            if (!result.IsSuccess || result.Result == null || string.IsNullOrWhiteSpace(result.Result.IdRecurso))
+                return new Response<WebhookRecordDto> { Error = result.Error ?? new ErrorResult("registerFailed") };
+
+            var record = new WebhookRecordDto
+            {
+                IntegrationId = integrationResponse.Result.Id,
+                Event = webhookDto.Event,
+                Method = webhookDto.Method,
+                Url = webhookDto.Url,
+                Uuid = result.Result.IdRecurso
+            };
+
+            var saved = await _webhookRepository.AddAsync(record);
+
+            return new Response<WebhookRecordDto>(saved);
         }
     }
 }


### PR DESCRIPTION
## Summary
- handle webhook persistence inside `WebhookService`
- streamline `WebhookController` by delegating to the service
- adapt unit tests to cover new `RegisterAsync` workflow

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68792a6b85248328a1ab361f9f003307