### PR TITLE
Add tracker for processed orders

### DIFF
--- a/src/LexosHub.ERP.VarejoOnline.Infra.CrossCutting/Default/IProcessedOrdersTracker.cs
+++ b/src/LexosHub.ERP.VarejoOnline.Infra.CrossCutting/Default/IProcessedOrdersTracker.cs
@@ -1,0 +1,8 @@
+namespace LexosHub.ERP.VarejoOnline.Infra.CrossCutting.Default
+{
+    public interface IProcessedOrdersTracker
+    {
+        bool IsProcessed(string orderNumber);
+        void MarkProcessed(string orderNumber);
+    }
+}

--- a/src/LexosHub.ERP.VarejoOnline.Infra.CrossCutting/Default/ProcessedOrdersFileTracker.cs
+++ b/src/LexosHub.ERP.VarejoOnline.Infra.CrossCutting/Default/ProcessedOrdersFileTracker.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace LexosHub.ERP.VarejoOnline.Infra.CrossCutting.Default
+{
+    /// <summary>
+    /// Tracks processed orders in a plain text file. Each line contains a processed order number.
+    /// </summary>
+    public class ProcessedOrdersFileTracker : IProcessedOrdersTracker
+    {
+        private readonly string _filePath;
+        private readonly HashSet<string> _orders;
+
+        public ProcessedOrdersFileTracker(string filePath)
+        {
+            _filePath = filePath ?? throw new ArgumentNullException(nameof(filePath));
+            _orders = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+            if (File.Exists(_filePath))
+            {
+                foreach (var line in File.ReadAllLines(_filePath))
+                {
+                    var order = line.Trim();
+                    if (!string.IsNullOrEmpty(order))
+                        _orders.Add(order);
+                }
+            }
+        }
+
+        public bool IsProcessed(string orderNumber)
+        {
+            if (string.IsNullOrWhiteSpace(orderNumber))
+                throw new ArgumentException("Value cannot be null or whitespace.", nameof(orderNumber));
+
+            return _orders.Contains(orderNumber.Trim());
+        }
+
+        public void MarkProcessed(string orderNumber)
+        {
+            if (string.IsNullOrWhiteSpace(orderNumber))
+                throw new ArgumentException("Value cannot be null or whitespace.", nameof(orderNumber));
+
+            orderNumber = orderNumber.Trim();
+            if (_orders.Add(orderNumber))
+            {
+                File.AppendAllLines(_filePath, new[] { orderNumber });
+            }
+        }
+    }
+}

--- a/tests/LexosHub.ERP.VarejoOnline.Domain.Tests/CrossCutting/ProcessedOrdersFileTrackerTests.cs
+++ b/tests/LexosHub.ERP.VarejoOnline.Domain.Tests/CrossCutting/ProcessedOrdersFileTrackerTests.cs
@@ -1,0 +1,39 @@
+using System;
+using System.IO;
+using LexosHub.ERP.VarejoOnline.Infra.CrossCutting.Default;
+using Xunit;
+
+namespace LexosHub.ERP.VarejoOnline.Domain.Tests.CrossCutting
+{
+    public class ProcessedOrdersFileTrackerTests
+    {
+        [Fact]
+        public void MarkProcessed_ShouldPersistAndAvoidDuplicates()
+        {
+            var path = Path.GetTempFileName();
+            try
+            {
+                var tracker = new ProcessedOrdersFileTracker(path);
+                tracker.MarkProcessed("123");
+                tracker.MarkProcessed("123");
+                tracker.MarkProcessed("456");
+
+                Assert.True(tracker.IsProcessed("123"));
+                Assert.True(tracker.IsProcessed("456"));
+                Assert.False(tracker.IsProcessed("789"));
+
+                var lines = File.ReadAllLines(path);
+                Assert.Equal(2, lines.Length);
+
+                // create a new instance to ensure persistence
+                var tracker2 = new ProcessedOrdersFileTracker(path);
+                Assert.True(tracker2.IsProcessed("123"));
+                Assert.True(tracker2.IsProcessed("456"));
+            }
+            finally
+            {
+                File.Delete(path);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add utility to persist processed order numbers
- add tests for the tracker

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68891d3d6a888328b9349b90a08c5bf7