### PR TITLE
feat: map configurable product

### DIFF
--- a/src/LexosHub.ERP.VarejOnline.Infra.Messaging/Mappers/Produto/ProdutoConfiguravelViewMapper.cs
+++ b/src/LexosHub.ERP.VarejOnline.Infra.Messaging/Mappers/Produto/ProdutoConfiguravelViewMapper.cs
@@ -1,12 +1,49 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using Lexos.Hub.Sync.Models.Produto;
+using LexosHub.ERP.VarejOnline.Infra.VarejOnlineApi.Responses;
 
 namespace LexosHub.ERP.VarejOnline.Infra.Messaging.Mappers.Produto
 {
     public static class ProdutoConfiguravelViewMapper
     {
+        public static ProdutoView? Map(ProdutoResponse produtoBase, List<ProdutoResponse> variacoes)
+        {
+            if (produtoBase == null)
+            {
+                return null;
+            }
+
+            var produtoView = ProdutoSimplesViewMapper.Map(produtoBase);
+            if (produtoView == null)
+            {
+                return null;
+            }
+
+            produtoView.ProdutoTipoId = Lexos.Hub.Sync.Constantes.Produto.CONFIGURAVEL;
+            produtoView.Variacoes = variacoes?.Select(MapVariacao).ToList() ?? new List<ProdutoVariacaoView>();
+
+            return produtoView;
+        }
+
+        private static ProdutoVariacaoView MapVariacao(ProdutoResponse source)
+        {
+            var tamanho = source.ValorAtributos?.FirstOrDefault(a => a.Nome.Equals("TAMANHO", StringComparison.OrdinalIgnoreCase))?.Valor;
+            var cor = source.ValorAtributos?.FirstOrDefault(a => a.Nome.Equals("COR", StringComparison.OrdinalIgnoreCase))?.Valor;
+
+            return new ProdutoVariacaoView
+            {
+                ProdutoIdGlobal = source.Id,
+                ProdutoId = source.Id,
+                Sku = source.CodigoSistema?.Trim(),
+                EAN = source.CodigoBarras,
+                Tamanho = tamanho,
+                Cor = cor,
+                Deleted = !source.Ativo,
+                OutrasVariacoes = new List<OutraVariacao>(),
+                ReferenciasOutrasPlataformas = new List<ProdutoReferenciaView>()
+            };
+        }
     }
 }

--- a/tests/LexosHub.ERP.VarejOnline.Domain.Tests/Mappers/ProdutoViewMapperTests.cs
+++ b/tests/LexosHub.ERP.VarejOnline.Domain.Tests/Mappers/ProdutoViewMapperTests.cs
@@ -195,4 +195,65 @@ namespace LexosHub.ERP.VarejOnline.Domain.Tests.Mappers
             Assert.Equal(0, result.Altura);
         }
     }
+
+        [Fact]
+        public void MapConfiguravel_ShouldMapVariacoes()
+        {
+            var produtoBase = new ProdutoResponse
+            {
+                Id = 10,
+                Descricao = "Produto Base",
+                CodigoSku = "BASE",
+                CodigoSistema = "BASE",
+                MercadoriaBase = true,
+            };
+
+            var variacoes = new List<ProdutoResponse>
+            {
+                new ProdutoResponse
+                {
+                    Id = 11,
+                    CodigoSistema = "VAR1",
+                    CodigoBarras = "EAN1",
+                    Ativo = true,
+                    ValorAtributos = new List<ValorAtributoResponse>
+                    {
+                        new ValorAtributoResponse { Nome = "TAMANHO", Valor = "M" },
+                        new ValorAtributoResponse { Nome = "COR", Valor = "Azul" }
+                    }
+                },
+                new ProdutoResponse
+                {
+                    Id = 12,
+                    CodigoSistema = "VAR2",
+                    CodigoBarras = "EAN2",
+                    Ativo = false,
+                    ValorAtributos = new List<ValorAtributoResponse>
+                    {
+                        new ValorAtributoResponse { Nome = "TAMANHO", Valor = "G" },
+                        new ValorAtributoResponse { Nome = "COR", Valor = "Vermelho" }
+                    }
+                }
+            };
+
+            var result = ProdutoConfiguravelViewMapper.Map(produtoBase, variacoes)!;
+
+            Assert.Equal(Lexos.Hub.Sync.Constantes.Produto.CONFIGURAVEL, result.ProdutoTipoId);
+            Assert.Equal(2, result.Variacoes.Count);
+
+            var v1 = result.Variacoes[0];
+            Assert.Equal("VAR1", v1.Sku);
+            Assert.Equal("EAN1", v1.EAN);
+            Assert.Equal("M", v1.Tamanho);
+            Assert.Equal("Azul", v1.Cor);
+            Assert.True(v1.Deleted == false);
+
+            var v2 = result.Variacoes[1];
+            Assert.Equal("VAR2", v2.Sku);
+            Assert.Equal("EAN2", v2.EAN);
+            Assert.Equal("G", v2.Tamanho);
+            Assert.Equal("Vermelho", v2.Cor);
+            Assert.True(v2.Deleted);
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- implement mapper for configurable products and variations
- refine simple product mapper to include id, SKU and configurável validation
- add unit tests for configurável mapping

## Testing
- `dotnet test` *(fails: command not found)*
- `curl -L https://dot.net/v1/dotnet-install.sh` *(fails: CONNECT tunnel 403)*
- `apt-get update` *(fails: repository 403)*

------
https://chatgpt.com/codex/tasks/task_e_6894a04821908328900cf359a821fd48