### PR TITLE
Inject ProdutoViewMapper into product handler

### DIFF
--- a/src/LexosHub.ERP.VarejOnline.Api/Program.cs
+++ b/src/LexosHub.ERP.VarejOnline.Api/Program.cs
@@ -18,6 +18,7 @@ using LexosHub.ERP.VarejOnline.Infra.Data.Repositories.Persistence;
 using LexosHub.ERP.VarejOnline.Infra.Messaging.Dispatcher;
 using LexosHub.ERP.VarejOnline.Infra.Messaging.Events;
 using LexosHub.ERP.VarejOnline.Infra.Messaging.Handlers;
+using LexosHub.ERP.VarejOnline.Infra.Messaging.Mappers.Produto;
 using LexosHub.ERP.VarejOnline.Infra.Messaging.Services;
 using LexosHub.ERP.VarejOnline.Infra.VarejOnlineApi.Services;
 using Microsoft.EntityFrameworkCore;
@@ -51,6 +52,7 @@ try
     builder.Services.AddTransient<IVarejOnlineApiService, VarejOnlineApiService>();
     builder.Services.AddTransient<ISqsRepository, SqsRepository>();
     builder.Services.AddTransient<IWebhookService, WebhookService>();
+    builder.Services.AddTransient<ProdutoViewMapper>();
 
     builder.Services.AddScoped<IIntegrationRepository, IntegrationRepository>();
     builder.Services.AddScoped<IWebhookRepository, WebhookRepository>();

--- a/src/LexosHub.ERP.VarejOnline.Infra.Messaging/Mappers/Produto/ProdutoViewMapper.cs
+++ b/src/LexosHub.ERP.VarejOnline.Infra.Messaging/Mappers/Produto/ProdutoViewMapper.cs
@@ -1,0 +1,28 @@
+using System.Collections.Generic;
+using System.Linq;
+using Lexos.Hub.Sync.Models.Produto;
+using LexosHub.ERP.VarejOnline.Infra.VarejOnlineApi.Responses;
+
+namespace LexosHub.ERP.VarejOnline.Infra.Messaging.Mappers.Produto
+{
+    public class ProdutoViewMapper
+    {
+        public ProdutoView? MapSimples(ProdutoResponse? source)
+        {
+            return ProdutoSimplesViewMapper.Map(source);
+        }
+
+        public List<ProdutoView> MapSimples(IEnumerable<ProdutoResponse>? source)
+        {
+            return source?.Select(MapSimples)
+                .Where(v => v != null)
+                .Cast<ProdutoView>()
+                .ToList() ?? new List<ProdutoView>();
+        }
+
+        public ProdutoView? MapConfiguravel(ProdutoResponse produtoBase, List<ProdutoResponse> variacoes)
+        {
+            return ProdutoConfiguravelViewMapper.Map(produtoBase, variacoes);
+        }
+    }
+}

--- a/tests/LexosHub.ERP.VarejOnline.Domain.Tests/Mappers/ProdutoViewMapperTests.cs
+++ b/tests/LexosHub.ERP.VarejOnline.Domain.Tests/Mappers/ProdutoViewMapperTests.cs
@@ -8,10 +8,12 @@ namespace LexosHub.ERP.VarejOnline.Domain.Tests.Mappers
 {
     public class ProdutoViewMapperTests
     {
+        private readonly ProdutoViewMapper _mapper = new();
+
         [Fact]
         public void Map_ShouldReturnNull_WhenSourceIsNull()
         {
-            var result = ProdutoSimplesViewMapper.Map((ProdutoResponse?)null);
+            var result = _mapper.MapSimples((ProdutoResponse?)null);
             Assert.Null(result);
         }
 
@@ -33,7 +35,7 @@ namespace LexosHub.ERP.VarejOnline.Domain.Tests.Mappers
                 }
             };
 
-            var result = source.Map();
+            var result = _mapper.MapSimples(source);
 
             Assert.Single(result);
             var item = result[0];
@@ -57,7 +59,7 @@ namespace LexosHub.ERP.VarejOnline.Domain.Tests.Mappers
                 CodigoSku = "SKU"
             };
 
-            var result = ProdutoSimplesViewMapper.Map(source)!;
+            var result = _mapper.MapSimples(source)!;
 
             Assert.NotNull(result.Precos);
             Assert.Empty(result.Precos);
@@ -88,7 +90,7 @@ namespace LexosHub.ERP.VarejOnline.Domain.Tests.Mappers
                 CodigoSku = "  " + sku + "  "
             };
 
-            var result = ProdutoSimplesViewMapper.Map(source)!;
+            var result = _mapper.MapSimples(source)!;
 
             Assert.Equal(50, result.Sku!.Length);
             Assert.False(result.Sku.StartsWith(" "));
@@ -109,7 +111,7 @@ namespace LexosHub.ERP.VarejOnline.Domain.Tests.Mappers
                 Largura = null
             };
 
-            var result = ProdutoSimplesViewMapper.Map(source)!;
+            var result = _mapper.MapSimples(source)!;
 
             Assert.Equal(0, result.Peso);
             Assert.Equal(0, result.Altura);
@@ -129,7 +131,7 @@ namespace LexosHub.ERP.VarejOnline.Domain.Tests.Mappers
                 ValorAtributos = new List<ValorAtributoResponse>()
             };
 
-            var result = ProdutoSimplesViewMapper.Map(source);
+            var result = _mapper.MapSimples(source);
 
             Assert.Null(result);
         }
@@ -150,7 +152,7 @@ namespace LexosHub.ERP.VarejOnline.Domain.Tests.Mappers
                 CodigoBarras = longEan
             };
 
-            var result = ProdutoSimplesViewMapper.Map(source)!;
+            var result = _mapper.MapSimples(source)!;
 
             Assert.True(result.Nome!.Length <= 255);
             Assert.True(result.DescricaoResumida!.Length <= 255);
@@ -168,7 +170,7 @@ namespace LexosHub.ERP.VarejOnline.Domain.Tests.Mappers
                 Categorias = null
             };
 
-            var result = ProdutoSimplesViewMapper.Map(source)!;
+            var result = _mapper.MapSimples(source)!;
 
             Assert.Null(result.Marca);
             Assert.Empty(result.Categorias);
@@ -184,7 +186,7 @@ namespace LexosHub.ERP.VarejOnline.Domain.Tests.Mappers
                 CodigoSku = "  SKU  "
             };
 
-            var result = ProdutoSimplesViewMapper.Map(source)!;
+            var result = _mapper.MapSimples(source)!;
 
             Assert.Equal("Produto", result.Nome);
             Assert.Equal("SKU", result.Sku);
@@ -236,7 +238,7 @@ namespace LexosHub.ERP.VarejOnline.Domain.Tests.Mappers
                 }
             };
 
-            var result = ProdutoConfiguravelViewMapper.Map(produtoBase, variacoes)!;
+            var result = _mapper.MapConfiguravel(produtoBase, variacoes)!;
 
             Assert.Equal(Lexos.Hub.Sync.Constantes.Produto.CONFIGURAVEL, result.ProdutoTipoId);
             Assert.Equal(2, result.Variacoes.Count);

--- a/tests/LexosHub.ERP.VarejOnline.Domain.Tests/Messaging/ProductsPageProcessedEventHandlerTests.cs
+++ b/tests/LexosHub.ERP.VarejOnline.Domain.Tests/Messaging/ProductsPageProcessedEventHandlerTests.cs
@@ -3,6 +3,7 @@ using LexosHub.ERP.VarejOnline.Domain.Interfaces.Repositories.Integration;
 using LexosHub.ERP.VarejOnline.Infra.CrossCutting.Settings;
 using LexosHub.ERP.VarejOnline.Infra.Messaging.Events;
 using LexosHub.ERP.VarejOnline.Infra.Messaging.Handlers;
+using LexosHub.ERP.VarejOnline.Infra.Messaging.Mappers.Produto;
 using LexosHub.ERP.VarejOnline.Infra.VarejOnlineApi.Responses;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -23,7 +24,7 @@ namespace LexosHub.ERP.VarejOnline.Domain.Tests.Messaging
         private readonly Mock<IOptions<SyncOutConfig>> _syncOutSqsConfigMock = new();
 
         private CriarProdutosSimplesEventHandler CreateHandler() =>
-            new CriarProdutosSimplesEventHandler(_logger.Object, _sqsRepository.Object, _syncOutSqsConfigMock.Object);
+            new CriarProdutosSimplesEventHandler(_logger.Object, _sqsRepository.Object, _syncOutSqsConfigMock.Object, new ProdutoViewMapper());
 
         [Fact]
         public async Task HandleAsync_ShouldLogInformation()


### PR DESCRIPTION
## Summary
- add ProdutoViewMapper to map simple and configurable products
- inject ProdutoViewMapper in CriarProdutosSimplesEventHandler and revalidate notifications
- register new mapper and adapt tests to new contract

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: The repository ... is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_6894b881fdc48328a7fcbd18f266d30a