### PR TITLE
test: add messaging product base and variations tests

### DIFF
--- a/tests/LexosHub.ERP.VarejOnline.Domain.Tests/Messaging/ProductsRequestedEventHandlerTests.cs
+++ b/tests/LexosHub.ERP.VarejOnline.Domain.Tests/Messaging/ProductsRequestedEventHandlerTests.cs
@@ -66,6 +66,27 @@ namespace LexosHub.ERP.VarejOnline.Domain.Tests.Messaging
         }
 
         [Fact]
+        public async Task HandleAsync_WithProdutoBase_ShouldCallApiServiceWithProdutoBase()
+        {
+            var evt = new ProductsRequested
+            {
+                HubKey = "key",
+                ProdutoBase = 10
+            };
+
+            var integration = new IntegrationDto { Token = "token" };
+            _integrationService.Setup(s => s.GetIntegrationByKeyAsync("key"))
+                .ReturnsAsync(new Response<IntegrationDto>(integration));
+
+            await CreateHandler().HandleAsync(evt, CancellationToken.None);
+
+            _apiService.Verify(a => a.GetProdutosAsync(
+                    "token",
+                    It.Is<ProdutoRequest>(r => r.ProdutoBase == evt.ProdutoBase)
+                ), Times.Once);
+        }
+
+        [Fact]
         public async Task HandleAsync_ShouldProcessAllPagesAndDispatchEvents()
         {
             var evt = new ProductsRequested


### PR DESCRIPTION
## Summary
- ensure ProductsRequestedEventHandler forwards ProdutoBase to GetProdutosAsync
- validate configurable product handler populates variations and dispatches to SQS

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository 'http://archive.ubuntu.com/ubuntu noble InRelease' is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_6894c0b29c2c83288c7a79eb855522b6