### PR TITLE
feat: add pedido creation endpoint

### DIFF
--- a/src/LexosHub.ERP.VarejOnline.Api/Controllers/Pedido/PedidoController.cs
+++ b/src/LexosHub.ERP.VarejOnline.Api/Controllers/Pedido/PedidoController.cs
@@ -1,12 +1,26 @@
-﻿using Microsoft.AspNetCore.Mvc;
+using LexosHub.ERP.VarejOnline.Domain.DTOs.Pedido;
+using LexosHub.ERP.VarejOnline.Domain.Interfaces.Services;
+using Microsoft.AspNetCore.Mvc;
 
 namespace LexosHub.ERP.VarejOnline.Api.Controllers.Pedido
 {
+    [ApiController]
+    [Route("api/pedidos")]
     public class PedidoController : Controller
     {
-        public IActionResult Index()
+        private readonly IPedidoService _pedidoService;
+
+        public PedidoController(IPedidoService pedidoService)
         {
-            return View();
+            _pedidoService = pedidoService;
+        }
+
+        [HttpPost]
+        public async Task<IActionResult> CreateAsync([FromBody] PedidoDto pedido)
+        {
+            var result = await _pedidoService.CreateAsync(pedido);
+            return Ok(result);
         }
     }
 }
+


### PR DESCRIPTION
## Summary
- convert PedidoController to API controller with `api/pedidos` route
- add POST `CreateAsync` action delegating to `IPedidoService`

## Testing
- `dotnet test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68995d186b5483288a9e27e7489e23fe