### PR TITLE
Add pedido request and response with API post method

### DIFF
--- a/src/LexosHub.ERP.VarejOnline.Infra.ErpApi/Interfaces/IVarejoOnlineApiService.cs
+++ b/src/LexosHub.ERP.VarejOnline.Infra.ErpApi/Interfaces/IVarejoOnlineApiService.cs
@@ -16,4 +16,5 @@ public interface IVarejOnlineApiService
     Task<Response<List<EstoqueResponse>>> GetEstoquesAsync(string token, EstoqueRequest request);
     Task<Response<WebhookOperationResponse>> RegisterWebhookAsync(string token, WebhookRequest payload, CancellationToken cancellationToken = default);
     Task<Response<List<TabelaPrecoListResponse>>> GetPriceTablesAsync(string token, TabelaPrecoRequest request);
+    Task<Response<PedidoResponse>> PostPedidoAsync(string token, PedidoRequest request);
 }

--- a/src/LexosHub.ERP.VarejOnline.Infra.ErpApi/Request/PedidoRequest.cs
+++ b/src/LexosHub.ERP.VarejOnline.Infra.ErpApi/Request/PedidoRequest.cs
@@ -1,0 +1,14 @@
+using System;
+using Newtonsoft.Json;
+
+namespace LexosHub.ERP.VarejOnline.Infra.ErpApi.Request
+{
+    public class PedidoRequest
+    {
+        [JsonProperty("codigo")]
+        public string Codigo { get; set; } = string.Empty;
+
+        [JsonProperty("data")]
+        public DateTime? Data { get; set; }
+    }
+}

--- a/src/LexosHub.ERP.VarejOnline.Infra.ErpApi/Responses/Pedido/PedidoResponse.cs
+++ b/src/LexosHub.ERP.VarejOnline.Infra.ErpApi/Responses/Pedido/PedidoResponse.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace LexosHub.ERP.VarejOnline.Infra.VarejOnlineApi.Responses
+{
+    public class PedidoResponse
+    {
+        public long Id { get; set; }
+        public string Codigo { get; set; } = string.Empty;
+        public DateTime? Data { get; set; }
+    }
+}

--- a/src/LexosHub.ERP.VarejOnline.Infra.ErpApi/Services/VarejoOnlineApiService.cs
+++ b/src/LexosHub.ERP.VarejOnline.Infra.ErpApi/Services/VarejoOnlineApiService.cs
@@ -224,7 +224,14 @@ namespace LexosHub.ERP.VarejOnline.Infra.VarejOnlineApi.Services
         #endregion
 
         #region Pedido
+        public async Task<Response<PedidoResponse>> PostPedidoAsync(string token, PedidoRequest request)
+        {
+            var restRequest = new RestRequest("apps/api/pedidos", Method.Post)
+                .AddHeader("Content-Type", "application/json")
+                .AddJsonBody(request);
 
+            return await ExecuteAsync<PedidoResponse>(restRequest, token);
+        }
         #endregion
 
         #region WebhookRegister


### PR DESCRIPTION
## Summary
- add `PedidoRequest` and `PedidoResponse`
- allow posting pedidos via `PostPedidoAsync`

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: The repository 'http://archive.ubuntu.com/ubuntu noble InRelease' is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68995d34b7188328b7e140f65f56c579