### PR TITLE
Add pedido endpoint to VarejOnline API service

### DIFF
--- a/src/LexosHub.ERP.VarejOnline.Infra.CrossCutting/Settings/VarejoOnlineApiSettings.cs
+++ b/src/LexosHub.ERP.VarejOnline.Infra.CrossCutting/Settings/VarejoOnlineApiSettings.cs
@@ -7,6 +7,7 @@ namespace LexosHub.ERP.VarejOnline.Infra.CrossCutting.Settings
         public string? OAuthGetTokenUrl { get; set; }
         public string? OAuthRedirectUrl { get; set; }
         public string? WebhookEndpoint { get; set; }
+        public string? PedidoUrl { get; set; }
         public string? ClientId { get; set; }
         public string? ClientSecret { get; set; }
     }

--- a/src/LexosHub.ERP.VarejOnline.Infra.ErpApi/Interfaces/IVarejoOnlineApiService.cs
+++ b/src/LexosHub.ERP.VarejOnline.Infra.ErpApi/Interfaces/IVarejoOnlineApiService.cs
@@ -16,4 +16,5 @@ public interface IVarejOnlineApiService
     Task<Response<List<EstoqueResponse>>> GetEstoquesAsync(string token, EstoqueRequest request);
     Task<Response<WebhookOperationResponse>> RegisterWebhookAsync(string token, WebhookRequest payload, CancellationToken cancellationToken = default);
     Task<Response<List<TabelaPrecoListResponse>>> GetPriceTablesAsync(string token, TabelaPrecoRequest request);
+    Task<Response<PedidoResponse>> PostPedidoAsync(string token, PedidoRequest payload);
 }

--- a/src/LexosHub.ERP.VarejOnline.Infra.ErpApi/Responses/Pedido/PedidoRequest.cs
+++ b/src/LexosHub.ERP.VarejOnline.Infra.ErpApi/Responses/Pedido/PedidoRequest.cs
@@ -1,0 +1,6 @@
+namespace LexosHub.ERP.VarejOnline.Infra.VarejOnlineApi.Request
+{
+    public class PedidoRequest
+    {
+    }
+}

--- a/src/LexosHub.ERP.VarejOnline.Infra.ErpApi/Responses/Pedido/PedidoResponse.cs
+++ b/src/LexosHub.ERP.VarejOnline.Infra.ErpApi/Responses/Pedido/PedidoResponse.cs
@@ -1,0 +1,6 @@
+namespace LexosHub.ERP.VarejOnline.Infra.VarejOnlineApi.Responses
+{
+    public class PedidoResponse
+    {
+    }
+}

--- a/src/LexosHub.ERP.VarejOnline.Infra.ErpApi/Services/VarejoOnlineApiService.cs
+++ b/src/LexosHub.ERP.VarejOnline.Infra.ErpApi/Services/VarejoOnlineApiService.cs
@@ -23,6 +23,7 @@ namespace LexosHub.ERP.VarejOnline.Infra.VarejOnlineApi.Services
         private string _clientSecret;
         private string _oAuthUrl;
         private string _webHookEnpoint;
+        private string _pedidoEndpoint;
 
         // JsonSerializerOptions global para System.Text.Json
         private static readonly JsonSerializerOptions DefaultJsonOptions = new()
@@ -46,6 +47,7 @@ namespace LexosHub.ERP.VarejOnline.Infra.VarejOnlineApi.Services
             _oAuthUrl = _erpApiSettings.OAuthUrl ?? string.Empty;
             _oAuthUrl = _erpApiSettings.OAuthUrl ?? string.Empty;
             _webHookEnpoint = _erpApiSettings.WebhookEndpoint ?? string.Empty;
+            _pedidoEndpoint = _erpApiSettings.PedidoUrl ?? string.Empty;
         }
 
         #region Auth
@@ -224,6 +226,15 @@ namespace LexosHub.ERP.VarejOnline.Infra.VarejOnlineApi.Services
         #endregion
 
         #region Pedido
+
+        public async Task<Response<PedidoResponse>> PostPedidoAsync(string token, PedidoRequest payload)
+        {
+            var request = new RestRequest(_pedidoEndpoint, Method.Post)
+                .AddHeader("Content-Type", "application/json")
+                .AddJsonBody(payload);
+
+            return await ExecuteAsync<PedidoResponse>(request, token);
+        }
 
         #endregion
 


### PR DESCRIPTION
## Summary
- expose `PedidoUrl` configuration and endpoint
- post orders with `PedidoRequest` via VarejOnline API

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68995d35f6dc8328b675e65003437f3d