### PR TITLE
Add pedido service and AutoMapper profile

### DIFF
--- a/src/LexosHub.ERP.VarejOnline.Api/Program.cs
+++ b/src/LexosHub.ERP.VarejOnline.Api/Program.cs
@@ -21,6 +21,7 @@ using LexosHub.ERP.VarejOnline.Infra.Messaging.Handlers;
 using LexosHub.ERP.VarejOnline.Infra.Messaging.Mappers.Produto;
 using LexosHub.ERP.VarejOnline.Infra.Messaging.Services;
 using LexosHub.ERP.VarejOnline.Infra.VarejOnlineApi.Services;
+using LexosHub.ERP.VarejOnline.Domain.Mappers;
 using Microsoft.EntityFrameworkCore;
 using Serilog;
 using System.Diagnostics;
@@ -52,6 +53,8 @@ try
     builder.Services.AddTransient<IVarejOnlineApiService, VarejOnlineApiService>();
     builder.Services.AddTransient<ISqsRepository, SqsRepository>();
     builder.Services.AddTransient<IWebhookService, WebhookService>();
+    builder.Services.AddTransient<IPedidoService, PedidoService>();
+    builder.Services.AddAutoMapper(typeof(PedidoProfile));
     builder.Services.AddTransient<ProdutoViewMapper>();
 
     builder.Services.AddScoped<IIntegrationRepository, IntegrationRepository>();

--- a/src/LexosHub.ERP.VarejOnline.Domain/DTOs/Pedido/PedidoDto.cs
+++ b/src/LexosHub.ERP.VarejOnline.Domain/DTOs/Pedido/PedidoDto.cs
@@ -1,0 +1,9 @@
+namespace LexosHub.ERP.VarejOnline.Domain.DTOs.Pedido
+{
+    public class PedidoDto
+    {
+        public long PedidoId { get; set; }
+        public string? Codigo { get; set; }
+        public decimal? Total { get; set; }
+    }
+}

--- a/src/LexosHub.ERP.VarejOnline.Domain/Interfaces/Services/IPedidoService.cs
+++ b/src/LexosHub.ERP.VarejOnline.Domain/Interfaces/Services/IPedidoService.cs
@@ -1,0 +1,11 @@
+using Lexos.Hub.Sync.Models.Pedido;
+using LexosHub.ERP.VarejOnline.Domain.DTOs.Pedido;
+using LexosHub.ERP.VarejOnline.Infra.CrossCutting.Default;
+
+namespace LexosHub.ERP.VarejOnline.Domain.Interfaces.Services
+{
+    public interface IPedidoService
+    {
+        Task<Response<PedidoDto>> MapPedidoAsync(PedidoView view);
+    }
+}

--- a/src/LexosHub.ERP.VarejOnline.Domain/Mappers/PedidoProfile.cs
+++ b/src/LexosHub.ERP.VarejOnline.Domain/Mappers/PedidoProfile.cs
@@ -1,0 +1,14 @@
+using AutoMapper;
+using Lexos.Hub.Sync.Models.Pedido;
+using LexosHub.ERP.VarejOnline.Domain.DTOs.Pedido;
+
+namespace LexosHub.ERP.VarejOnline.Domain.Mappers
+{
+    public class PedidoProfile : Profile
+    {
+        public PedidoProfile()
+        {
+            CreateMap<PedidoView, PedidoDto>();
+        }
+    }
+}

--- a/src/LexosHub.ERP.VarejOnline.Domain/Services/PedidoService.cs
+++ b/src/LexosHub.ERP.VarejOnline.Domain/Services/PedidoService.cs
@@ -1,0 +1,24 @@
+using AutoMapper;
+using Lexos.Hub.Sync.Models.Pedido;
+using LexosHub.ERP.VarejOnline.Domain.DTOs.Pedido;
+using LexosHub.ERP.VarejOnline.Domain.Interfaces.Services;
+using LexosHub.ERP.VarejOnline.Infra.CrossCutting.Default;
+
+namespace LexosHub.ERP.VarejOnline.Domain.Services
+{
+    public class PedidoService : IPedidoService
+    {
+        private readonly IMapper _mapper;
+
+        public PedidoService(IMapper mapper)
+        {
+            _mapper = mapper;
+        }
+
+        public Task<Response<PedidoDto>> MapPedidoAsync(PedidoView view)
+        {
+            var dto = _mapper.Map<PedidoDto>(view);
+            return Task.FromResult(new Response<PedidoDto>(dto));
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add IPedidoService and PedidoService for pedido mapping
- register PedidoService and related AutoMapper profile

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-8.0` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68995d384fd08328894c162d6db50126