### PR TITLE
Add support for updating Varejo Online order status

### DIFF
--- a/src/Lexos.Hub.Sync/Models/Pedido/AlterarStatusPedidoView.cs
+++ b/src/Lexos.Hub.Sync/Models/Pedido/AlterarStatusPedidoView.cs
@@ -1,0 +1,15 @@
+namespace Lexos.Hub.Sync.Models.Pedido
+{
+    public class AlterarStatusPedidoView
+    {
+        public long IdPedido { get; set; }
+        public string Status { get; set; }
+        public StatusPedidoVendaView StatusPedidoVenda { get; set; }
+    }
+
+    public class StatusPedidoVendaView
+    {
+        public long? Id { get; set; }
+        public string Nome { get; set; }
+    }
+}

--- a/src/LexosHub.ERP.VarejOnline.Api/Controllers/Pedido/PedidoController.cs
+++ b/src/LexosHub.ERP.VarejOnline.Api/Controllers/Pedido/PedidoController.cs
@@ -20,7 +20,14 @@ namespace LexosHub.ERP.VarejOnline.Api.Controllers.Pedido
         public async Task<IActionResult> EnviarPedido([FromBody] PedidoView pedido, string hubKey)
         {
             var result = await _pedidoService.EnviarPedido(hubKey, pedido);
-            return Ok(result);
+            return StatusCode((int)result.StatusCode, result);
+        }
+
+        [HttpPost("alterar-status")]
+        public async Task<IActionResult> AlterarStatus([FromBody] AlterarStatusPedidoView payload, string hubKey)
+        {
+            var result = await _pedidoService.AlterarStatusPedido(hubKey, payload);
+            return StatusCode((int)result.StatusCode, result);
         }
     }
 }

--- a/src/LexosHub.ERP.VarejOnline.Domain/Interfaces/Services/IPedidoService.cs
+++ b/src/LexosHub.ERP.VarejOnline.Domain/Interfaces/Services/IPedidoService.cs
@@ -2,11 +2,13 @@ using Lexos.Hub.Sync.Models.Pedido;
 using LexosHub.ERP.VarejOnline.Domain.DTOs.Pedido;
 using LexosHub.ERP.VarejOnline.Infra.CrossCutting.Default;
 using LexosHub.ERP.VarejOnline.Infra.VarejOnlineApi.Responses;
+using AlterarStatusResponse = LexosHub.ERP.VarejOnline.Infra.VarejOnlineApi.Responses.AlterarStatusPedidoResponse;
 
 namespace LexosHub.ERP.VarejOnline.Domain.Interfaces.Services
 {
     public interface IPedidoService
     {
         Task<Response<PedidoResponse>> EnviarPedido(string hubKey, PedidoView pedidoView);
+        Task<Response<AlterarStatusResponse>> AlterarStatusPedido(string hubKey, AlterarStatusPedidoView payload);
     }
 }

--- a/src/LexosHub.ERP.VarejOnline.Domain/Services/PedidoService.cs
+++ b/src/LexosHub.ERP.VarejOnline.Domain/Services/PedidoService.cs
@@ -4,6 +4,8 @@ using LexosHub.ERP.VarejOnline.Domain.Interfaces.Services;
 using LexosHub.ERP.VarejOnline.Domain.Mappers;
 using LexosHub.ERP.VarejOnline.Infra.CrossCutting.Default;
 using LexosHub.ERP.VarejOnline.Infra.VarejOnlineApi.Responses;
+using LexosHub.ERP.VarejOnline.Infra.ErpApi.Request.Pedido;
+using AlterarStatusResponse = LexosHub.ERP.VarejOnline.Infra.VarejOnlineApi.Responses.AlterarStatusPedidoResponse;
 
 namespace LexosHub.ERP.VarejOnline.Domain.Services
 {
@@ -30,6 +32,30 @@ namespace LexosHub.ERP.VarejOnline.Domain.Services
             var request = VarejoOnlinePedidoMapper.Map(pedidoView);
 
             return await _apiService.PostPedidoAsync(token, request);
+        }
+
+        public async Task<Response<AlterarStatusResponse>> AlterarStatusPedido(string hubKey, AlterarStatusPedidoView payload)
+        {
+            if (payload == null) throw new ArgumentNullException(nameof(payload));
+
+            var integration = await _integrationService.GetIntegrationByKeyAsync(hubKey);
+            if (integration.Result == null)
+                return new Response<AlterarStatusResponse> { Error = integration.Error ?? new ErrorResult("integrationNotFound") };
+
+            var token = integration.Result.Token ?? string.Empty;
+
+            var request = new AlterarStatusPedidoRequest
+            {
+                IdPedido = payload.IdPedido,
+                Status = payload.Status,
+                StatusPedidoVenda = payload.StatusPedidoVenda == null ? null : new StatusPedidoVendaRequest
+                {
+                    Id = payload.StatusPedidoVenda.Id,
+                    Nome = payload.StatusPedidoVenda.Nome
+                }
+            };
+
+            return await _apiService.AlterarStatusPedidoAsync(token, request);
         }
     }
 }

--- a/src/LexosHub.ERP.VarejOnline.Infra.ErpApi/Interfaces/IVarejoOnlineApiService.cs
+++ b/src/LexosHub.ERP.VarejOnline.Infra.ErpApi/Interfaces/IVarejoOnlineApiService.cs
@@ -18,4 +18,5 @@ public interface IVarejOnlineApiService
     Task<Response<WebhookOperationResponse>> RegisterWebhookAsync(string token, WebhookRequest payload, CancellationToken cancellationToken = default);
     Task<Response<List<TabelaPrecoListResponse>>> GetPriceTablesAsync(string token, TabelaPrecoRequest request);
     Task<Response<PedidoResponse>> PostPedidoAsync(string token, PedidoRequest request);
+    Task<Response<AlterarStatusPedidoResponse>> AlterarStatusPedidoAsync(string token, AlterarStatusPedidoRequest request);
 }

--- a/src/LexosHub.ERP.VarejOnline.Infra.ErpApi/Request/Pedido/AlterarStatusPedidoRequest.cs
+++ b/src/LexosHub.ERP.VarejOnline.Infra.ErpApi/Request/Pedido/AlterarStatusPedidoRequest.cs
@@ -1,0 +1,25 @@
+using Newtonsoft.Json;
+
+namespace LexosHub.ERP.VarejOnline.Infra.ErpApi.Request.Pedido
+{
+    public class AlterarStatusPedidoRequest
+    {
+        [JsonProperty("idPedido")]
+        public long IdPedido { get; set; }
+
+        [JsonProperty("status")]
+        public string Status { get; set; } = string.Empty;
+
+        [JsonProperty("statusPedidoVenda")]
+        public StatusPedidoVendaRequest? StatusPedidoVenda { get; set; }
+    }
+
+    public class StatusPedidoVendaRequest
+    {
+        [JsonProperty("id")]
+        public long? Id { get; set; }
+
+        [JsonProperty("nome")]
+        public string? Nome { get; set; }
+    }
+}

--- a/src/LexosHub.ERP.VarejOnline.Infra.ErpApi/Responses/Pedido/AlterarStatusPedidoResponse.cs
+++ b/src/LexosHub.ERP.VarejOnline.Infra.ErpApi/Responses/Pedido/AlterarStatusPedidoResponse.cs
@@ -1,0 +1,25 @@
+using System.Text.Json.Serialization;
+
+namespace LexosHub.ERP.VarejOnline.Infra.VarejOnlineApi.Responses
+{
+    public class AlterarStatusPedidoResponse
+    {
+        [JsonPropertyName("idPedido")]
+        public long IdPedido { get; set; }
+
+        [JsonPropertyName("status")]
+        public string? Status { get; set; }
+
+        [JsonPropertyName("statusPedidoVenda")]
+        public StatusPedidoVendaResponse? StatusPedidoVenda { get; set; }
+    }
+
+    public class StatusPedidoVendaResponse
+    {
+        [JsonPropertyName("id")]
+        public long? Id { get; set; }
+
+        [JsonPropertyName("nome")]
+        public string? Nome { get; set; }
+    }
+}

--- a/src/LexosHub.ERP.VarejOnline.Infra.ErpApi/Services/VarejoOnlineApiService.cs
+++ b/src/LexosHub.ERP.VarejOnline.Infra.ErpApi/Services/VarejoOnlineApiService.cs
@@ -234,6 +234,15 @@ namespace LexosHub.ERP.VarejOnline.Infra.VarejOnlineApi.Services
             return await ExecuteAsync<PedidoResponse>(restRequest, token);
         }
 
+        public async Task<Response<AlterarStatusPedidoResponse>> AlterarStatusPedidoAsync(string token, AlterarStatusPedidoRequest request)
+        {
+            var restRequest = new RestRequest("apps/api/pedidos/alterar-status", Method.Post)
+                .AddHeader("Content-Type", "application/json")
+                .AddJsonBody(request);
+
+            return await ExecuteAsync<AlterarStatusPedidoResponse>(restRequest, token);
+        }
+
         #endregion
 
         #region WebhookRegister


### PR DESCRIPTION
## Summary
- add DTO and API models for order status changes
- wire AlterarStatusPedido through service and API client
- expose alterar-status endpoint in PedidoController

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6899dd40d11c8328a11ff84c10c575db