### PR TITLE
feat: add kit product mapper

### DIFF
--- a/src/LexosHub.ERP.VarejOnline.Infra.Messaging/Mappers/Produto/ProdutoKitViewMapper.cs
+++ b/src/LexosHub.ERP.VarejOnline.Infra.Messaging/Mappers/Produto/ProdutoKitViewMapper.cs
@@ -1,0 +1,34 @@
+using Lexos.Hub.Sync.Models.Produto;
+using LexosHub.ERP.VarejOnline.Infra.VarejOnlineApi.Responses;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace LexosHub.ERP.VarejOnline.Infra.Messaging.Mappers.Produto
+{
+    public static class ProdutoKitViewMapper
+    {
+        public static ProdutoView? Map(ProdutoResponse produtoBase)
+        {
+            if (produtoBase == null)
+            {
+                return null;
+            }
+
+            var produtoView = ProdutoSimplesViewMapper.Map(produtoBase);
+            if (produtoView == null)
+            {
+                return null;
+            }
+
+            produtoView.ProdutoTipoId = Lexos.Hub.Sync.Constantes.Produto.COMPOSTO;
+            produtoView.Composicao = produtoBase.Componentes?.Select(c => new ProdutoComposicaoView
+            {
+                ProdutoIdGlobal = c.Produto.Id,
+                Sku = c.Produto.CodigoSistema,
+                Quantidade = double.Parse(c.Quantidade.ToString())
+            }).ToList() ?? new List<ProdutoComposicaoView>();
+
+            return produtoView;
+        }
+    }
+}

--- a/src/LexosHub.ERP.VarejOnline.Infra.Messaging/Mappers/Produto/ProdutoViewMapper.cs
+++ b/src/LexosHub.ERP.VarejOnline.Infra.Messaging/Mappers/Produto/ProdutoViewMapper.cs
@@ -24,5 +24,18 @@ namespace LexosHub.ERP.VarejOnline.Infra.Messaging.Mappers.Produto
         {
             return ProdutoConfiguravelViewMapper.Map(produtoBase, variacoes);
         }
+
+        public ProdutoView? MapKit(ProdutoResponse produtoBase)
+        {
+            return ProdutoKitViewMapper.Map(produtoBase);
+        }
+
+        public List<ProdutoView> MapKit(IEnumerable<ProdutoResponse>? source)
+        {
+            return source?.Select(MapKit)
+                .Where(v => v != null)
+                .Cast<ProdutoView>()
+                .ToList() ?? new List<ProdutoView>();
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add ProdutoKitViewMapper to handle kit products
- expose MapKit methods in ProdutoViewMapper

## Testing
- `dotnet test LexosHub.VarejoOnline.sln` *(fails: command not found)*
- `apt-get update` *(fails: repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689b4f751e0c8328a876e1f4c3a25282