### PR TITLE
Fix kit mapping in ProdutoViewMapper

### DIFF
--- a/src/LexosHub.ERP.VarejOnline.Infra.Messaging/Mappers/Produto/ProdutoViewMapper.cs
+++ b/src/LexosHub.ERP.VarejOnline.Infra.Messaging/Mappers/Produto/ProdutoViewMapper.cs
@@ -20,11 +20,6 @@ namespace LexosHub.ERP.VarejOnline.Infra.Messaging.Mappers.Produto
                 .ToList() ?? new List<ProdutoView>();
         }
 
-        public List<ProdutoView> MapKits(IEnumerable<ProdutoResponse>? source)
-        {
-            return MapSimples(source);
-        }
-
         public ProdutoView? MapConfiguravel(ProdutoResponse produtoBase, List<ProdutoResponse> variacoes)
         {
             return ProdutoConfiguravelViewMapper.Map(produtoBase, variacoes);
@@ -32,10 +27,20 @@ namespace LexosHub.ERP.VarejOnline.Infra.Messaging.Mappers.Produto
 
         public ProdutoView? MapKit(ProdutoResponse produtoBase)
         {
-            return ProdutoKitViewMapper.Map(produtoBase);
+            var produto = ProdutoSimplesViewMapper.Map(produtoBase);
+
+            if (produto == null)
+            {
+                return null;
+            }
+
+            produto.ProdutoTipoId = Lexos.Hub.Sync.Constantes.Produto.COMPOSTO;
+            produto.Composicao = ProdutoKitViewMapper.Map(produtoBase.Componentes);
+
+            return produto;
         }
 
-        public List<ProdutoView> MapKit(IEnumerable<ProdutoResponse>? source)
+        public List<ProdutoView> MapKits(IEnumerable<ProdutoResponse>? source)
         {
             return source?.Select(MapKit)
                 .Where(v => v != null)

--- a/tests/LexosHub.ERP.VarejOnline.Domain.Tests/Mappers/ProdutoViewMapperTests.cs
+++ b/tests/LexosHub.ERP.VarejOnline.Domain.Tests/Mappers/ProdutoViewMapperTests.cs
@@ -257,5 +257,54 @@ namespace LexosHub.ERP.VarejOnline.Domain.Tests.Mappers
             Assert.Equal("Vermelho", v2.Cor);
             Assert.True(v2.Deleted);
         }
+
+        [Fact]
+        public void MapKit_ShouldMapComposicaoAndSetTipo()
+        {
+            var produtoBase = new ProdutoResponse
+            {
+                Id = 20,
+                Descricao = "Kit Produto",
+                CodigoSku = "KIT",
+                Componentes = new List<ComponenteResponse>
+                {
+                    new ComponenteResponse
+                    {
+                        Quantidade = 2,
+                        Unidade = "UN",
+                        Produto = new ComponenteProdutoResponse
+                        {
+                            Id = 30,
+                            CodigoSistema = "SKU1"
+                        }
+                    },
+                    new ComponenteResponse
+                    {
+                        Quantidade = 1,
+                        Unidade = "UN",
+                        Produto = new ComponenteProdutoResponse
+                        {
+                            Id = 31,
+                            CodigoSistema = "SKU2"
+                        }
+                    }
+                }
+            };
+
+            var result = _mapper.MapKit(produtoBase)!;
+
+            Assert.Equal(Lexos.Hub.Sync.Constantes.Produto.COMPOSTO, result.ProdutoTipoId);
+            Assert.Equal(2, result.Composicao.Count);
+
+            var c1 = result.Composicao[0];
+            Assert.Equal(30, c1.ProdutoId);
+            Assert.Equal("SKU1", c1.Sku);
+            Assert.Equal(2, c1.Quantidade);
+
+            var c2 = result.Composicao[1];
+            Assert.Equal(31, c2.ProdutoId);
+            Assert.Equal("SKU2", c2.Sku);
+            Assert.Equal(1, c2.Quantidade);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Map product kit to ProdutoView via ProdutoSimplesViewMapper and set composition
- Test mapping logic for kits

## Testing
- `dotnet test` *(command failed: bash: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_689bdc729bfc83288d807869b2d724a7