### PR TITLE
feat: handle ERP store requests

### DIFF
--- a/src/LexosHub.ERP.VarejOnline.Api/Program.cs
+++ b/src/LexosHub.ERP.VarejOnline.Api/Program.cs
@@ -87,6 +87,7 @@ try
     builder.Services.AddTransient<IEventHandler<PriceTablesRequested>, PriceTablesRequestedEventHandler>();
     builder.Services.AddTransient<IEventHandler<PriceTablePageProcessed>, PriceTablesPageProcessedEventHandler>();
     builder.Services.AddTransient<IEventHandler<CompaniesRequested>, CompaniesRequestedEventHandler>();
+    builder.Services.AddTransient<IEventHandler<StoresRequested>, StoresRequestedEventHandler>();
     builder.Services.AddHostedService<SqsListenerService>();
 
     var app = builder.Build().SetupMiddlewares();

--- a/src/LexosHub.ERP.VarejOnline.Infra.ErpApi/Interfaces/IVarejoOnlineApiService.cs
+++ b/src/LexosHub.ERP.VarejOnline.Infra.ErpApi/Interfaces/IVarejoOnlineApiService.cs
@@ -5,6 +5,7 @@ using LexosHub.ERP.VarejOnline.Infra.ErpApi.Requests.Produto;
 using LexosHub.ERP.VarejOnline.Infra.ErpApi.Responses.Auth;
 using LexosHub.ERP.VarejOnline.Infra.ErpApi.Responses.Prices;
 using LexosHub.ERP.VarejOnline.Infra.ErpApi.Responses.Webhook;
+using LexosHub.ERP.VarejOnline.Infra.ErpApi.Responses.Empresa;
 using LexosHub.ERP.VarejOnline.Infra.VarejOnlineApi.Request;
 using LexosHub.ERP.VarejOnline.Infra.VarejOnlineApi.Responses;
 
@@ -12,6 +13,7 @@ public interface IVarejOnlineApiService
 {
     Task<Response<TokenResponse?>> ExchangeCodeForTokenAsync(string code);
     Task<string> GetAuthUrl();
+    Task<Response<List<EntidadeResponse>>> GetEntidadesAsync(string token, bool somenteAtivas);
     Task<Response<List<EmpresaResponse>>> GetEmpresasAsync(string token, EmpresaRequest request);
     Task<Response<List<ProdutoResponse>>> GetProdutosAsync(string token, ProdutoRequest request);
     Task<Response<List<EstoqueResponse>>> GetEstoquesAsync(string token, EstoqueRequest request);

--- a/src/LexosHub.ERP.VarejOnline.Infra.ErpApi/Services/VarejoOnlineApiService.cs
+++ b/src/LexosHub.ERP.VarejOnline.Infra.ErpApi/Services/VarejoOnlineApiService.cs
@@ -6,6 +6,7 @@ using LexosHub.ERP.VarejOnline.Infra.ErpApi.Requests.Produto;
 using LexosHub.ERP.VarejOnline.Infra.ErpApi.Responses.Auth;
 using LexosHub.ERP.VarejOnline.Infra.ErpApi.Responses.Prices;
 using LexosHub.ERP.VarejOnline.Infra.ErpApi.Responses.Webhook;
+using LexosHub.ERP.VarejOnline.Infra.ErpApi.Responses.Empresa;
 using LexosHub.ERP.VarejOnline.Infra.VarejOnlineApi.Request;
 using LexosHub.ERP.VarejOnline.Infra.VarejOnlineApi.Responses;
 using Microsoft.Extensions.Options;
@@ -73,6 +74,16 @@ namespace LexosHub.ERP.VarejOnline.Infra.VarejOnlineApi.Services
         public Task<string> GetAuthUrl()
         {
             return Task.FromResult($"{_erpApiSettings.BaseUrl}{_oAuthUrl}client_id={_clientId}&redirect_uri={_oAuthRedirectUrl}");
+        }
+        #endregion
+
+        #region Entidades
+        public async Task<Response<List<EntidadeResponse>>> GetEntidadesAsync(string token, bool somenteAtivas)
+        {
+            var restRequest = new RestRequest("entidades", Method.Get);
+            restRequest.AddQueryParameter("somenteAtivas", somenteAtivas.ToString().ToLower());
+
+            return await ExecuteAsync<List<EntidadeResponse>>(restRequest, token);
         }
         #endregion
 

--- a/src/LexosHub.ERP.VarejOnline.Infra.Messaging/Events/StoresRequested.cs
+++ b/src/LexosHub.ERP.VarejOnline.Infra.Messaging/Events/StoresRequested.cs
@@ -1,0 +1,7 @@
+namespace LexosHub.ERP.VarejOnline.Infra.Messaging.Events
+{
+    public class StoresRequested : BaseEvent
+    {
+        public string HubKey { get; set; } = null!;
+    }
+}

--- a/src/LexosHub.ERP.VarejOnline.Infra.Messaging/Handlers/StoresRequestedEventHandler.cs
+++ b/src/LexosHub.ERP.VarejOnline.Infra.Messaging/Handlers/StoresRequestedEventHandler.cs
@@ -1,0 +1,53 @@
+using LexosHub.ERP.VarejOnline.Domain.Interfaces.Services;
+using LexosHub.ERP.VarejOnline.Infra.CrossCutting.Settings;
+using LexosHub.ERP.VarejOnline.Infra.Messaging.Events;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+
+namespace LexosHub.ERP.VarejOnline.Infra.Messaging.Handlers
+{
+    public class StoresRequestedEventHandler : IEventHandler<StoresRequested>
+    {
+        private readonly ILogger<StoresRequestedEventHandler> _logger;
+        private readonly IIntegrationService _integrationService;
+        private readonly IVarejOnlineApiService _apiService;
+        private readonly SyncOutConfig _syncOutConfig;
+
+        public StoresRequestedEventHandler(
+            ILogger<StoresRequestedEventHandler> logger,
+            IIntegrationService integrationService,
+            IVarejOnlineApiService apiService,
+            IOptions<SyncOutConfig> syncOutConfig)
+        {
+            _logger = logger;
+            _integrationService = integrationService;
+            _apiService = apiService;
+            _syncOutConfig = syncOutConfig.Value;
+        }
+
+        public async Task HandleAsync(StoresRequested @event, CancellationToken cancellationToken)
+        {
+            _logger.LogInformation("Stores requested for hub {HubKey}", @event.HubKey);
+
+            var integrationResponse = await _integrationService.GetIntegrationByKeyAsync(@event.HubKey);
+            var token = integrationResponse.Result?.Token ?? string.Empty;
+
+            var entidadesResponse = await _apiService.GetEntidadesAsync(token, true);
+            var entidades = entidadesResponse.Result ?? new List<LexosHub.ERP.VarejOnline.Infra.ErpApi.Responses.Empresa.EntidadeResponse>();
+
+            var payload = entidades.Select(e => new { LojaGlobalId = e.Id, NomeFantasia = e.Nome }).ToList();
+
+            var requestUrl = $"{_syncOutConfig.ApiUrl}Settings/AtualizarInformacoesHubVindasErpExterno";
+            using var httpClient = new HttpClient();
+            if (!string.IsNullOrEmpty(token))
+            {
+                httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+            }
+            var content = new StringContent(JsonSerializer.Serialize(payload), Encoding.UTF8, "application/json");
+            await httpClient.PostAsync(requestUrl, content, cancellationToken);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `StoresRequested` event
- implement `StoresRequestedEventHandler` to fetch ERP entities and sync with hub API
- extend ERP API service with `GetEntidadesAsync`
- register new handler in startup

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a617d118e08328b1e5c6ab7da87cfc