### PR TITLE
Create missing customer before sending order

### DIFF
--- a/src/LexosHub.ERP.VarejOnline.Domain/Services/PedidoService.cs
+++ b/src/LexosHub.ERP.VarejOnline.Domain/Services/PedidoService.cs
@@ -3,7 +3,10 @@ using LexosHub.ERP.VarejOnline.Domain.DTOs.Pedido;
 using LexosHub.ERP.VarejOnline.Domain.Interfaces.Services;
 using LexosHub.ERP.VarejOnline.Domain.Mappers;
 using LexosHub.ERP.VarejOnline.Infra.CrossCutting.Default;
+using LexosHub.ERP.VarejOnline.Infra.ErpApi.Request.Pedido;
+using LexosHub.ERP.VarejOnline.Infra.VarejOnlineApi.Request;
 using LexosHub.ERP.VarejOnline.Infra.VarejOnlineApi.Responses;
+using System.Linq;
 using System.Net;
 
 namespace LexosHub.ERP.VarejOnline.Domain.Services
@@ -28,9 +31,58 @@ namespace LexosHub.ERP.VarejOnline.Domain.Services
                 return new Response<PedidoResponse> { Error = integration.Error ?? new ErrorResult("integrationNotFound") };
 
             var token = integration.Result.Token ?? string.Empty;
+
+            long? terceiroId = null;
+
+            if (!string.IsNullOrWhiteSpace(pedidoView.ClienteCpfcnpj))
+            {
+                var terceiroResponse = await _apiService.GetTerceiroByDocumentoAsync(token, pedidoView.ClienteCpfcnpj);
+                if (!terceiroResponse.IsSuccess)
+                    return new Response<PedidoResponse> { Error = terceiroResponse.Error, StatusCode = terceiroResponse.StatusCode };
+
+                terceiroId = terceiroResponse.Result?.FirstOrDefault()?.Id;
+
+                if (!terceiroId.HasValue)
+                {
+                    var terceiroRequest = BuildTerceiroRequest(pedidoView);
+                    var createResponse = await _apiService.CreateTerceiroAsync(token, terceiroRequest);
+
+                    if (createResponse.Result == null)
+                        return new Response<PedidoResponse> { Error = createResponse.Error ?? new ErrorResult("terceiroCreationFailed"), StatusCode = createResponse.StatusCode };
+
+                    terceiroId = createResponse.Result.Id;
+                }
+            }
+
             var request = VarejoOnlinePedidoMapper.Map(pedidoView);
 
+            if (request != null && terceiroId.HasValue)
+                request.Terceiro = new TerceiroRef { Id = terceiroId };
+
             return await _apiService.PostPedidoAsync(token, request);
+        }
+
+        private static TerceiroRequest BuildTerceiroRequest(PedidoView pedidoView)
+        {
+            var contato = pedidoView.Contatos?.FirstOrDefault();
+            var endereco = pedidoView.Enderecos?.FirstOrDefault();
+
+            return new TerceiroRequest
+            {
+                Nome = pedidoView.ClienteNome ?? string.Empty,
+                Documento = pedidoView.ClienteCpfcnpj ?? string.Empty,
+                Contato = contato?.Nome,
+                Telefone = contato?.Telefone,
+                Email = contato?.Email,
+                Endereco = endereco?.Endereco,
+                Numero = endereco?.Numero,
+                Complemento = endereco?.Complemento,
+                Bairro = endereco?.Bairro,
+                Cidade = endereco?.Cidade,
+                Uf = endereco?.Uf,
+                Pais = endereco?.Pais,
+                Cep = endereco?.Cep
+            };
         }
 
         public async Task<Response<PedidoResponse>> AlterarStatusPedido(string hubKey, long pedidoNumero, string novoStatus)

--- a/src/LexosHub.ERP.VarejOnline.Infra.ErpApi/Interfaces/IVarejoOnlineApiService.cs
+++ b/src/LexosHub.ERP.VarejOnline.Infra.ErpApi/Interfaces/IVarejoOnlineApiService.cs
@@ -21,4 +21,6 @@ public interface IVarejOnlineApiService
     Task<Response<PedidoResponse>> PostPedidoAsync(string token, PedidoRequest request);
     Task<Response<PedidoResponse>> AlterarStatusPedidoAsync(string token, long pedidoNumero, string novoStatus);
     Task<Response<List<EntidadeResponse>>> GetEntidadesAsync(string token);
+    Task<Response<List<TerceiroResponse>>> GetTerceiroByDocumentoAsync(string token, string documento);
+    Task<Response<TerceiroResponse?>> CreateTerceiroAsync(string token, TerceiroRequest request);
 }

--- a/src/LexosHub.ERP.VarejOnline.Infra.ErpApi/Request/TerceiroRequest.cs
+++ b/src/LexosHub.ERP.VarejOnline.Infra.ErpApi/Request/TerceiroRequest.cs
@@ -1,0 +1,19 @@
+namespace LexosHub.ERP.VarejOnline.Infra.VarejOnlineApi.Request
+{
+    public class TerceiroRequest
+    {
+        public string Nome { get; set; } = string.Empty;
+        public string Documento { get; set; } = string.Empty;
+        public string? Contato { get; set; }
+        public string? Telefone { get; set; }
+        public string? Email { get; set; }
+        public string? Endereco { get; set; }
+        public string? Numero { get; set; }
+        public string? Complemento { get; set; }
+        public string? Bairro { get; set; }
+        public string? Cidade { get; set; }
+        public string? Uf { get; set; }
+        public string? Pais { get; set; }
+        public string? Cep { get; set; }
+    }
+}

--- a/src/LexosHub.ERP.VarejOnline.Infra.ErpApi/Responses/Terceiro/TerceiroResponse.cs
+++ b/src/LexosHub.ERP.VarejOnline.Infra.ErpApi/Responses/Terceiro/TerceiroResponse.cs
@@ -1,0 +1,8 @@
+namespace LexosHub.ERP.VarejOnline.Infra.VarejOnlineApi.Responses
+{
+    public class TerceiroResponse
+    {
+        public long Id { get; set; }
+        public string? Documento { get; set; }
+    }
+}

--- a/src/LexosHub.ERP.VarejOnline.Infra.ErpApi/Services/VarejoOnlineApiService.cs
+++ b/src/LexosHub.ERP.VarejOnline.Infra.ErpApi/Services/VarejoOnlineApiService.cs
@@ -116,6 +116,23 @@ namespace LexosHub.ERP.VarejOnline.Infra.VarejOnlineApi.Services
         }
         #endregion
 
+        #region Terceiros
+        public async Task<Response<List<TerceiroResponse>>> GetTerceiroByDocumentoAsync(string token, string documento)
+        {
+            var restRequest = new RestRequest("apps/api/terceiros", Method.Get);
+            if (!string.IsNullOrWhiteSpace(documento))
+                restRequest.AddQueryParameter("documento", documento);
+            return await ExecuteAsync<List<TerceiroResponse>>(restRequest, token);
+        }
+
+        public async Task<Response<TerceiroResponse?>> CreateTerceiroAsync(string token, TerceiroRequest request)
+        {
+            var restRequest = new RestRequest("apps/api/terceiros", Method.Post)
+                .AddJsonBody(request);
+            return await ExecuteAsync<TerceiroResponse?>(restRequest, token);
+        }
+        #endregion
+
         #region Prices
         public async Task<Response<List<TabelaPrecoListResponse>>> GetPriceTablesAsync(string token, TabelaPrecoRequest request)
         {

--- a/tests/LexosHub.ERP.VarejOnline.Domain.Tests/Services/PedidoServiceTests.cs
+++ b/tests/LexosHub.ERP.VarejOnline.Domain.Tests/Services/PedidoServiceTests.cs
@@ -1,9 +1,13 @@
+using System.Collections.Generic;
 using System.Net;
 using System.Threading.Tasks;
+using Lexos.Hub.Sync.Models.Pedido;
 using LexosHub.ERP.VarejOnline.Domain.DTOs.Integration;
 using LexosHub.ERP.VarejOnline.Domain.Services;
 using LexosHub.ERP.VarejOnline.Domain.Interfaces.Services;
 using LexosHub.ERP.VarejOnline.Infra.CrossCutting.Default;
+using LexosHub.ERP.VarejOnline.Infra.ErpApi.Request.Pedido;
+using LexosHub.ERP.VarejOnline.Infra.VarejOnlineApi.Request;
 using LexosHub.ERP.VarejOnline.Infra.VarejOnlineApi.Responses;
 using Moq;
 using Xunit;
@@ -46,6 +50,59 @@ namespace LexosHub.ERP.VarejOnline.Domain.Tests.Services
 
             Assert.False(result.IsSuccess);
             _apiService.Verify(a => a.AlterarStatusPedidoAsync(It.IsAny<string>(), It.IsAny<long>(), It.IsAny<string>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task EnviarPedido_ShouldCreateTerceiro_WhenNotFound()
+        {
+            var integration = new IntegrationDto { Token = "token" };
+            _integrationService.Setup(s => s.GetIntegrationByKeyAsync("hub"))
+                .ReturnsAsync(new Response<IntegrationDto> { Result = integration });
+
+            var pedidoView = new PedidoView
+            {
+                ClienteCpfcnpj = "123",
+                ClienteNome = "Cliente",
+                Contatos = new List<PedidoClienteContatoView> { new() { Nome = "Contato", Telefone = "999", Email = "c@e.com" } },
+                Enderecos = new List<PedidoClienteEnderecoView> { new() { Endereco = "Rua", Numero = "1", Bairro = "Bairro", Cidade = "Cidade", Uf = "UF", Pais = "BR", Cep = "123" } }
+            };
+
+            _apiService.Setup(a => a.GetTerceiroByDocumentoAsync("token", "123"))
+                .ReturnsAsync(new Response<List<TerceiroResponse>> { Result = new List<TerceiroResponse>() });
+
+            _apiService.Setup(a => a.CreateTerceiroAsync("token", It.Is<TerceiroRequest>(t => t.Documento == "123")))
+                .ReturnsAsync(new Response<TerceiroResponse?> { Result = new TerceiroResponse { Id = 10 } });
+
+            _apiService.Setup(a => a.PostPedidoAsync("token", It.Is<PedidoRequest>(p => p.Terceiro?.Id == 10)))
+                .ReturnsAsync(new Response<PedidoResponse> { Result = new PedidoResponse() });
+
+            var service = CreateService();
+            var result = await service.EnviarPedido("hub", pedidoView);
+
+            Assert.True(result.IsSuccess);
+            _apiService.Verify(a => a.CreateTerceiroAsync("token", It.IsAny<TerceiroRequest>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task EnviarPedido_ShouldAbort_WhenTerceiroCreationFails()
+        {
+            var integration = new IntegrationDto { Token = "token" };
+            _integrationService.Setup(s => s.GetIntegrationByKeyAsync("hub"))
+                .ReturnsAsync(new Response<IntegrationDto> { Result = integration });
+
+            var pedidoView = new PedidoView { ClienteCpfcnpj = "123", ClienteNome = "Cliente" };
+
+            _apiService.Setup(a => a.GetTerceiroByDocumentoAsync("token", "123"))
+                .ReturnsAsync(new Response<List<TerceiroResponse>> { Result = new List<TerceiroResponse>() });
+
+            _apiService.Setup(a => a.CreateTerceiroAsync("token", It.IsAny<TerceiroRequest>()))
+                .ReturnsAsync(new Response<TerceiroResponse?> { Error = new ErrorResult("fail") });
+
+            var service = CreateService();
+            var result = await service.EnviarPedido("hub", pedidoView);
+
+            Assert.False(result.IsSuccess);
+            _apiService.Verify(a => a.PostPedidoAsync(It.IsAny<string>(), It.IsAny<PedidoRequest>()), Times.Never);
         }
     }
 }


### PR DESCRIPTION
## Summary
- ensure PedidoService looks up customer by document and creates it when missing before posting order
- extend IVarejOnlineApiService and its implementation with Terceiro lookup/creation endpoints
- add TerceiroRequest/Response models and unit tests for customer creation logic

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*
- `apt-get install -y dotnet-sdk-8.0` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68abc430991883288d325c98e43f8197