### PR TITLE
feat: add terceiros api methods

### DIFF
--- a/src/LexosHub.ERP.VarejOnline.Infra.ErpApi/Interfaces/IVarejoOnlineApiService.cs
+++ b/src/LexosHub.ERP.VarejOnline.Infra.ErpApi/Interfaces/IVarejoOnlineApiService.cs
@@ -2,10 +2,12 @@ using LexosHub.ERP.VarejOnline.Infra.CrossCutting.Default;
 using LexosHub.ERP.VarejOnline.Infra.ErpApi.Request;
 using LexosHub.ERP.VarejOnline.Infra.ErpApi.Request.Pedido;
 using LexosHub.ERP.VarejOnline.Infra.ErpApi.Requests.Produto;
+using LexosHub.ERP.VarejOnline.Infra.ErpApi.Request.Clientes;
 using LexosHub.ERP.VarejOnline.Infra.ErpApi.Responses.Auth;
 using LexosHub.ERP.VarejOnline.Infra.ErpApi.Responses.Prices;
 using LexosHub.ERP.VarejOnline.Infra.ErpApi.Responses.Webhook;
 using LexosHub.ERP.VarejOnline.Infra.ErpApi.Responses.Empresa;
+using LexosHub.ERP.VarejOnline.Infra.VarejOnlineApi.Responses.Clientes;
 using LexosHub.ERP.VarejOnline.Infra.VarejOnlineApi.Request;
 using LexosHub.ERP.VarejOnline.Infra.VarejOnlineApi.Responses;
 
@@ -21,4 +23,6 @@ public interface IVarejOnlineApiService
     Task<Response<PedidoResponse>> PostPedidoAsync(string token, PedidoRequest request);
     Task<Response<PedidoResponse>> AlterarStatusPedidoAsync(string token, long pedidoNumero, string novoStatus);
     Task<Response<List<EntidadeResponse>>> GetEntidadesAsync(string token);
+    Task<Response<List<TerceiroResponse>>> GetTerceirosAsync(string token, TerceiroQueryRequest request);
+    Task<Response<TerceiroResponse>> CreateTerceiroAsync(string token, TerceiroRequest request);
 }

--- a/src/LexosHub.ERP.VarejOnline.Infra.ErpApi/Request/Clientes/TerceiroQueryRequest.cs
+++ b/src/LexosHub.ERP.VarejOnline.Infra.ErpApi/Request/Clientes/TerceiroQueryRequest.cs
@@ -1,0 +1,7 @@
+namespace LexosHub.ERP.VarejOnline.Infra.ErpApi.Request.Clientes
+{
+    public class TerceiroQueryRequest
+    {
+        public string Documento { get; set; } = string.Empty;
+    }
+}

--- a/src/LexosHub.ERP.VarejOnline.Infra.ErpApi/Request/Clientes/TerceiroRequest.cs
+++ b/src/LexosHub.ERP.VarejOnline.Infra.ErpApi/Request/Clientes/TerceiroRequest.cs
@@ -1,0 +1,35 @@
+using System.Collections.Generic;
+
+namespace LexosHub.ERP.VarejOnline.Infra.ErpApi.Request.Clientes
+{
+    public class TerceiroRequest
+    {
+        public string Nome { get; set; } = string.Empty;
+        public string Documento { get; set; } = string.Empty;
+        public string Tipo { get; set; } = string.Empty;
+        public string? Email { get; set; }
+        public string? Telefone { get; set; }
+        public List<TerceiroContatoRequest>? Contatos { get; set; }
+        public List<TerceiroEnderecoRequest>? Enderecos { get; set; }
+    }
+
+    public class TerceiroContatoRequest
+    {
+        public string? Nome { get; set; }
+        public string? Telefone { get; set; }
+        public string? Email { get; set; }
+    }
+
+    public class TerceiroEnderecoRequest
+    {
+        public string? Tipo { get; set; }
+        public string? Endereco { get; set; }
+        public string? Numero { get; set; }
+        public string? Bairro { get; set; }
+        public string? Cidade { get; set; }
+        public string? Uf { get; set; }
+        public string? Pais { get; set; }
+        public string? Cep { get; set; }
+        public string? Complemento { get; set; }
+    }
+}

--- a/src/LexosHub.ERP.VarejOnline.Infra.ErpApi/Responses/Clientes/TerceiroResponse.cs
+++ b/src/LexosHub.ERP.VarejOnline.Infra.ErpApi/Responses/Clientes/TerceiroResponse.cs
@@ -1,0 +1,36 @@
+using System.Collections.Generic;
+
+namespace LexosHub.ERP.VarejOnline.Infra.VarejOnlineApi.Responses.Clientes
+{
+    public class TerceiroResponse
+    {
+        public long Id { get; set; }
+        public string Nome { get; set; } = string.Empty;
+        public string Documento { get; set; } = string.Empty;
+        public string Tipo { get; set; } = string.Empty;
+        public string? Email { get; set; }
+        public string? Telefone { get; set; }
+        public List<TerceiroContatoResponse>? Contatos { get; set; }
+        public List<TerceiroEnderecoResponse>? Enderecos { get; set; }
+    }
+
+    public class TerceiroContatoResponse
+    {
+        public string? Nome { get; set; }
+        public string? Telefone { get; set; }
+        public string? Email { get; set; }
+    }
+
+    public class TerceiroEnderecoResponse
+    {
+        public string? Tipo { get; set; }
+        public string? Endereco { get; set; }
+        public string? Numero { get; set; }
+        public string? Bairro { get; set; }
+        public string? Cidade { get; set; }
+        public string? Uf { get; set; }
+        public string? Pais { get; set; }
+        public string? Cep { get; set; }
+        public string? Complemento { get; set; }
+    }
+}

--- a/src/LexosHub.ERP.VarejOnline.Infra.ErpApi/Services/VarejoOnlineApiService.cs
+++ b/src/LexosHub.ERP.VarejOnline.Infra.ErpApi/Services/VarejoOnlineApiService.cs
@@ -3,10 +3,12 @@ using LexosHub.ERP.VarejOnline.Infra.CrossCutting.Settings;
 using LexosHub.ERP.VarejOnline.Infra.ErpApi.Request;
 using LexosHub.ERP.VarejOnline.Infra.ErpApi.Request.Pedido;
 using LexosHub.ERP.VarejOnline.Infra.ErpApi.Requests.Produto;
+using LexosHub.ERP.VarejOnline.Infra.ErpApi.Request.Clientes;
 using LexosHub.ERP.VarejOnline.Infra.ErpApi.Responses.Auth;
 using LexosHub.ERP.VarejOnline.Infra.ErpApi.Responses.Prices;
 using LexosHub.ERP.VarejOnline.Infra.ErpApi.Responses.Webhook;
 using LexosHub.ERP.VarejOnline.Infra.ErpApi.Responses.Empresa;
+using LexosHub.ERP.VarejOnline.Infra.VarejOnlineApi.Responses.Clientes;
 using LexosHub.ERP.VarejOnline.Infra.VarejOnlineApi.Request;
 using LexosHub.ERP.VarejOnline.Infra.VarejOnlineApi.Responses;
 using Microsoft.Extensions.Options;
@@ -113,6 +115,24 @@ namespace LexosHub.ERP.VarejOnline.Infra.VarejOnlineApi.Services
             var resource = "apps/api/entidades";
             var restRequest = new RestRequest(resource, Method.Get);
             return await ExecuteAsync<List<EntidadeResponse>>(restRequest, token);
+        }
+        #endregion
+
+        #region Terceiros
+        public async Task<Response<List<TerceiroResponse>>> GetTerceirosAsync(string token, TerceiroQueryRequest request)
+        {
+            var restRequest = new RestRequest("apps/api/terceiros", Method.Get);
+            restRequest.AddQueryParameter("documento", request.Documento);
+            return await ExecuteAsync<List<TerceiroResponse>>(restRequest, token);
+        }
+
+        public async Task<Response<TerceiroResponse>> CreateTerceiroAsync(string token, TerceiroRequest request)
+        {
+            var restRequest = new RestRequest("apps/api/terceiros", Method.Post)
+                .AddHeader("Content-Type", "application/json")
+                .AddJsonBody(request);
+
+            return await ExecuteAsync<TerceiroResponse>(restRequest, token);
         }
         #endregion
 


### PR DESCRIPTION
## Summary
- add third-party query and creation models
- support VarejoOnline terceiros API in service and interface

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68abc4365d588328a50993d692e407d2