### PR TITLE
Map transport data in order mapper

### DIFF
--- a/src/LexosHub.ERP.VarejOnline.Domain/Mappers/VarejoOnlinePedidoMapper.cs
+++ b/src/LexosHub.ERP.VarejOnline.Domain/Mappers/VarejoOnlinePedidoMapper.cs
@@ -186,7 +186,13 @@ namespace LexosHub.ERP.VarejOnline.Domain.Mappers
                 return null;
             }
 
-            return new Transporte();
+            return new Transporte
+            {
+                Modalidade = source.TipoFrete,
+                Transportador = string.IsNullOrWhiteSpace(source.TransportadoraNome)
+                    ? null
+                    : new TerceiroRef { Documento = source.TransportadoraNome }
+            };
         }
     }
 }

--- a/tests/LexosHub.ERP.VarejOnline.Domain.Tests/Mappers/VarejoOnlinePedidoMapperTests.cs
+++ b/tests/LexosHub.ERP.VarejOnline.Domain.Tests/Mappers/VarejoOnlinePedidoMapperTests.cs
@@ -1,0 +1,45 @@
+using System;
+using Lexos.Hub.Sync.Models.Pedido;
+using LexosHub.ERP.VarejOnline.Domain.Mappers;
+using Xunit;
+
+namespace LexosHub.ERP.VarejOnline.Domain.Tests.Mappers
+{
+    public class VarejoOnlinePedidoMapperTests
+    {
+        [Fact]
+        public void Map_ShouldMapTransporte_WhenInfoProvided()
+        {
+            var pedido = new PedidoView
+            {
+                Codigo = "1",
+                Data = new DateTime(2024, 1, 1, 8, 0, 0),
+                TipoFrete = "CIF",
+                TransportadoraNome = "12345678000199"
+            };
+
+            var result = VarejoOnlinePedidoMapper.Map(pedido);
+
+            Assert.NotNull(result);
+            Assert.NotNull(result!.Transporte);
+            Assert.Equal("CIF", result.Transporte!.Modalidade);
+            Assert.NotNull(result.Transporte.Transportador);
+            Assert.Equal("12345678000199", result.Transporte.Transportador!.Documento);
+        }
+
+        [Fact]
+        public void Map_ShouldReturnNullTransporte_WhenNoInfo()
+        {
+            var pedido = new PedidoView
+            {
+                Codigo = "1",
+                Data = new DateTime(2024, 1, 1)
+            };
+
+            var result = VarejoOnlinePedidoMapper.Map(pedido);
+
+            Assert.NotNull(result);
+            Assert.Null(result!.Transporte);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- populate Transporte with freight mode and carrier document
- add unit tests for Pedido mapper transport mapping

## Testing
- `dotnet test LexosHub.VarejoOnline.sln` *(fails: dotnet: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b0a08d5d9c8328a8ca55a392296b36