### PR TITLE
feat: register default webhooks during initial sync

### DIFF
--- a/src/LexosHub.ERP.VarejOnline.Api/Program.cs
+++ b/src/LexosHub.ERP.VarejOnline.Api/Program.cs
@@ -83,6 +83,7 @@ try
     builder.Services.AddTransient<IEventHandler<PriceTablePageProcessed>, PriceTablesPageProcessedEventHandler>();
     builder.Services.AddTransient<IEventHandler<CompaniesRequested>, CompaniesRequestedEventHandler>();
     builder.Services.AddTransient<IEventHandler<StoresRequested>, StoresRequestedEventHandler>();
+    builder.Services.AddTransient<IEventHandler<RegisterDefaultWebhooks>, RegisterDefaultWebhooksEventHandler>();
     builder.Services.AddHostedService<SqsListenerService>();
 
     var app = builder.Build().SetupMiddlewares();

--- a/src/LexosHub.ERP.VarejOnline.Infra.Messaging/Events/RegisterDefaultWebhooks.cs
+++ b/src/LexosHub.ERP.VarejOnline.Infra.Messaging/Events/RegisterDefaultWebhooks.cs
@@ -1,0 +1,7 @@
+namespace LexosHub.ERP.VarejOnline.Infra.Messaging.Events
+{
+    public class RegisterDefaultWebhooks : BaseEvent
+    {
+        public string HubKey { get; set; } = null!;
+    }
+}

--- a/src/LexosHub.ERP.VarejOnline.Infra.Messaging/Handlers/InitialSyncEventHandler.cs
+++ b/src/LexosHub.ERP.VarejOnline.Infra.Messaging/Handlers/InitialSyncEventHandler.cs
@@ -24,6 +24,9 @@ namespace LexosHub.ERP.VarejOnline.Infra.Messaging.Handlers
 
             var storesEvent = new StoresRequested { HubKey = @event.HubKey };
             await _dispatcher.DispatchAsync(storesEvent, cancellationToken);
+
+            var webhooksEvent = new RegisterDefaultWebhooks { HubKey = @event.HubKey };
+            await _dispatcher.DispatchAsync(webhooksEvent, cancellationToken);
         }
     }
 }

--- a/src/LexosHub.ERP.VarejOnline.Infra.Messaging/Handlers/RegisterDefaultWebhooksEventHandler.cs
+++ b/src/LexosHub.ERP.VarejOnline.Infra.Messaging/Handlers/RegisterDefaultWebhooksEventHandler.cs
@@ -1,0 +1,45 @@
+using LexosHub.ERP.VarejOnline.Domain.DTOs.Produto;
+using LexosHub.ERP.VarejOnline.Domain.Interfaces.Services;
+using LexosHub.ERP.VarejOnline.Infra.Messaging.Events;
+using Microsoft.Extensions.Logging;
+
+namespace LexosHub.ERP.VarejOnline.Infra.Messaging.Handlers
+{
+    public class RegisterDefaultWebhooksEventHandler : IEventHandler<RegisterDefaultWebhooks>
+    {
+        private readonly ILogger<RegisterDefaultWebhooksEventHandler> _logger;
+        private readonly IWebhookService _webhookService;
+
+        public RegisterDefaultWebhooksEventHandler(
+            ILogger<RegisterDefaultWebhooksEventHandler> logger,
+            IWebhookService webhookService)
+        {
+            _logger = logger;
+            _webhookService = webhookService;
+        }
+
+        public async Task HandleAsync(RegisterDefaultWebhooks @event, CancellationToken cancellationToken)
+        {
+            _logger.LogInformation("Registering default webhooks for hub {HubKey}", @event.HubKey);
+
+            var events = new[] { "PRODUTOS", "TABELAPRECOPRODUTO", "NOTAFISCAL" };
+            var methods = new[] { "POST", "PUT" };
+
+            foreach (var evt in events)
+            {
+                foreach (var method in methods)
+                {
+                    var webhook = new WebhookDto
+                    {
+                        HubKey = @event.HubKey,
+                        Event = evt,
+                        Method = method,
+                        Url = $"https://api-varejoonline.lexoshub.com/{@event.HubKey}/{evt}"
+                    };
+
+                    await _webhookService.RegisterAsync(webhook, cancellationToken);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `RegisterDefaultWebhooks` event and handler
- dispatch default webhooks event during initial sync
- register default webhook handler

## Testing
- ⚠️ `dotnet test` *(dotnet: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c37642908c83288276815f7385dd42