### PR TITLE
Update InitialSync event handler tests to use dispatcher mock

### DIFF
--- a/tests/LexosHub.ERP.VarejOnline.Domain.Tests/Messaging/InitialSyncEventHandlerTests.cs
+++ b/tests/LexosHub.ERP.VarejOnline.Domain.Tests/Messaging/InitialSyncEventHandlerTests.cs
@@ -1,17 +1,8 @@
-using Amazon.SQS.Model;
-using Lexos.SQS.Interface;
-using LexosHub.ERP.VarejOnline.Infra.CrossCutting.Settings;
-using LexosHub.ERP.VarejOnline.Infra.Messaging.Converters;
 using LexosHub.ERP.VarejOnline.Infra.Messaging.Dispatcher;
 using LexosHub.ERP.VarejOnline.Infra.Messaging.Events;
 using LexosHub.ERP.VarejOnline.Infra.Messaging.Handlers;
-using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
 using Moq;
-using System.Collections.Generic;
-using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
@@ -21,37 +12,28 @@ namespace LexosHub.ERP.VarejOnline.Domain.Tests.Messaging
     public class InitialSyncEventHandlerTests
     {
         private readonly Mock<ILogger<InitialSyncEventHandler>> _logger = new();
-        private readonly Mock<IOptions<VarejOnlineSqsConfig>> _sqsConfig = new();
-        private readonly Mock<ISqsRepository> _sqs = new();
-        private readonly Mock<IServiceScopeFactory> _scope= new();
+        private readonly Mock<IEventDispatcher> _dispatcher = new();
 
         private InitialSyncEventHandler CreateHandler()
         {
-            var dispatcher = new EventDispatcher(_scope.Object);
-            return new InitialSyncEventHandler(_logger.Object, dispatcher);
+            return new InitialSyncEventHandler(_logger.Object, _dispatcher.Object);
         }
 
         [Fact]
-        public async Task HandleAsync_ShouldDispatchCompaniesRequested()
+        public async Task HandleAsync_ShouldDispatchExpectedEvents()
         {
             var evt = new InitialSync { HubKey = "key" };
+            var cancellationToken = CancellationToken.None;
 
-            await CreateHandler().HandleAsync(evt, CancellationToken.None);
+            await CreateHandler().HandleAsync(evt, cancellationToken);
 
-            _sqs.Verify(s => s.AdicionarMensagemFilaNormal(
-                It.Is<SendMessageRequest>(r => IsCompaniesRequestedWithHubKey(r, evt.HubKey))), Times.Once);
+            _dispatcher.Verify(d => d.DispatchAsync(
+                It.Is<StoresRequested>(e => e.HubKey == evt.HubKey),
+                It.Is<CancellationToken>(ct => ct == cancellationToken)), Times.Once);
 
-        }
-        private bool IsCompaniesRequestedWithHubKey(SendMessageRequest request, string hubKey)
-        {
-            var baseEvent = JsonSerializer.Deserialize<BaseEvent>(
-                request.MessageBody,
-                new JsonSerializerOptions { Converters = { new BaseEventJsonConverter() } }
-            );
-            if (baseEvent is CompaniesRequested c)
-                return c.HubKey == hubKey;
-
-            return false;
+            _dispatcher.Verify(d => d.DispatchAsync(
+                It.Is<RegisterDefaultWebhooks>(e => e.HubKey == evt.HubKey),
+                It.Is<CancellationToken>(ct => ct == cancellationToken)), Times.Once);
         }
 
     }


### PR DESCRIPTION
## Summary
- replace the SQS repository mock with an event dispatcher mock in the InitialSync handler tests
- verify that the dispatcher is invoked for StoresRequested and RegisterDefaultWebhooks events, reflecting the handler behaviour

## Testing
- dotnet test tests/LexosHub.ERP.VarejOnline.Domain.Tests/LexosHub.ERP.VarejOnline.Domain.Tests.csproj *(fails: `dotnet` not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cdc05319dc83289fc58059410cdea0