### PR TITLE
Atualiza testes do SqslEventPublisher

### DIFF
--- a/tests/LexosHub.ERP.VarejOnline.Domain.Tests/Messaging/SqsEventDispatcherTests.cs
+++ b/tests/LexosHub.ERP.VarejOnline.Domain.Tests/Messaging/SqsEventDispatcherTests.cs
@@ -1,15 +1,10 @@
-using Amazon.SQS;
-using Amazon.SQS.Model;
 using Lexos.SQS.Interface;
 using LexosHub.ERP.VarejOnline.Infra.CrossCutting.Settings;
-using LexosHub.ERP.VarejOnline.Infra.Messaging.Converters;
 using LexosHub.ERP.VarejOnline.Infra.Messaging.Dispatcher;
 using LexosHub.ERP.VarejOnline.Infra.Messaging.Events;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Options;
 using Moq;
 using System.Collections.Generic;
-using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
@@ -21,51 +16,83 @@ namespace LexosHub.ERP.VarejOnline.Domain.Tests.Messaging
         [Fact]
         public async Task DispatchAsync_ShouldSendSerializedEventToQueue()
         {
-            var _sqsConfig = new Mock<IOptions<VarejOnlineSqsConfig>>();
             var sqsRepository = new Mock<ISqsRepository>();
-            var inMemory = new Dictionary<string, string>
+            var sqsOptions = Options.Create(new VarejOnlineSqsConfig
             {
-                {"AWS:ServiceURL", "http://localhost"},
-                {"AWS:SQSQueues:IntegrationCreated", "queue/test"}
-            };
-            var configuration = new ConfigurationBuilder()
-                .AddInMemoryCollection(inMemory)
-                .Build();
+                SQSBaseUrl = "http://localhost/",
+                SQSAccessKeyId = "123456789",
+                SQSQueues = new Dictionary<string, string>
+                {
+                    { "IntegrationCreated", "queue/test" }
+                }
+            });
 
-            var dispatcher = new SqslEventPublisher(sqsRepository.Object, _sqsConfig.Object);
+            var dispatcher = new SqslEventPublisher(sqsRepository.Object, sqsOptions);
             var evt = new IntegrationCreated { HubKey = "key" };
 
             await dispatcher.DispatchAsync(evt, CancellationToken.None);
 
+            var expectedQueueUrl = "http://localhost/123456789/queue/test";
+
+            sqsRepository.Verify(s => s.IniciarFila(expectedQueueUrl, Lexos.SQS.Models.TipoConta.Production), Times.Once);
             sqsRepository.Verify(s => s.AdicionarMensagemFilaNormal(
-                It.Is<SendMessageRequest>(r =>
-                    r.QueueUrl == "http://localhost/queue/test" &&
-                    JsonSerializer.Deserialize<BaseEvent>(r.MessageBody, new JsonSerializerOptions { Converters = { new BaseEventJsonConverter() } }) is IntegrationCreated)), Times.Once);
+                It.Is<BaseEvent>(message => ReferenceEquals(message, evt))), Times.Once);
+            sqsRepository.Verify(s => s.AdicionarMensagemFilaFifo(It.IsAny<BaseEvent>(), It.IsAny<string>()), Times.Never);
         }
 
         [Fact]
         public async Task DispatchAsync_ShouldSendCriarProdutosKitsToConfiguredQueue()
         {
-            var _sqsConfig = new Mock<IOptions<VarejOnlineSqsConfig>>();
             var sqsRepository = new Mock<ISqsRepository>();
-            var inMemory = new Dictionary<string, string>
+            var sqsOptions = Options.Create(new VarejOnlineSqsConfig
             {
-                {"AWS:ServiceURL", "http://localhost"},
-                {"AWS:SQSQueues:ProdutosKits", "queue/produtokit"}
-            };
-            var configuration = new ConfigurationBuilder()
-                .AddInMemoryCollection(inMemory)
-                .Build();
+                SQSBaseUrl = "http://localhost/",
+                SQSAccessKeyId = "123456789",
+                SQSQueues = new Dictionary<string, string>
+                {
+                    { "Produtos", "queue/produtokit" }
+                }
+            });
 
-            var dispatcher = new SqslEventPublisher(sqsRepository.Object, _sqsConfig.Object);
+            var dispatcher = new SqslEventPublisher(sqsRepository.Object, sqsOptions);
             var evt = new CriarProdutosKits { HubKey = "key" };
 
             await dispatcher.DispatchAsync(evt, CancellationToken.None);
 
+            var expectedQueueUrl = "http://localhost/123456789/queue/produtokit";
+
+            sqsRepository.Verify(s => s.IniciarFila(expectedQueueUrl, Lexos.SQS.Models.TipoConta.Production), Times.Once);
             sqsRepository.Verify(s => s.AdicionarMensagemFilaNormal(
-                It.Is<SendMessageRequest>(r =>
-                    r.QueueUrl == "http://localhost/queue/produtokit" &&
-                    JsonSerializer.Deserialize<BaseEvent>(r.MessageBody, new JsonSerializerOptions { Converters = { new BaseEventJsonConverter() } }) is CriarProdutosKits)), Times.Once);
+                It.Is<BaseEvent>(message => ReferenceEquals(message, evt))), Times.Once);
+            sqsRepository.Verify(s => s.AdicionarMensagemFilaFifo(It.IsAny<BaseEvent>(), It.IsAny<string>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task DispatchAsync_ShouldHandleFifoQueues()
+        {
+            var sqsRepository = new Mock<ISqsRepository>();
+            var sqsOptions = Options.Create(new VarejOnlineSqsConfig
+            {
+                SQSBaseUrl = "http://localhost/",
+                SQSAccessKeyId = "123456789",
+                SQSQueues = new Dictionary<string, string>
+                {
+                    { "Produtos", "queue/produtos.fifo" }
+                }
+            });
+
+            var dispatcher = new SqslEventPublisher(sqsRepository.Object, sqsOptions);
+            var evt = new CriarProdutosSimples { HubKey = "fifo-hub" };
+
+            await dispatcher.DispatchAsync(evt, CancellationToken.None);
+
+            var expectedQueueUrl = "http://localhost/123456789/queue/produtos.fifo";
+
+            sqsRepository.Verify(s => s.IniciarFila(expectedQueueUrl, Lexos.SQS.Models.TipoConta.Production), Times.Once);
+            sqsRepository.Verify(s => s.AdicionarMensagemFilaFifo(
+                It.Is<BaseEvent>(message => ReferenceEquals(message, evt)),
+                It.Is<string>(group => group == evt.HubKey)), Times.Once);
+            sqsRepository.Verify(s => s.AdicionarMensagemFilaNormal(It.IsAny<BaseEvent>()), Times.Never);
         }
     }
 }


### PR DESCRIPTION
## Summary
- instantiate SqslEventPublisher in the tests with real options containing queue metadata
- update mocks to assert queue initialization and message publication using the actual events
- add a FIFO queue scenario to cover AdicionarMensagemFilaFifo

## Testing
- not run (dotnet CLI indisponível na imagem fornecida)


------
https://chatgpt.com/codex/tasks/task_e_68cdc0632d148328bb11fa51503378ed