### PR TITLE
Add event dispatcher tests for PedidoController

### DIFF
--- a/tests/LexosHub.ERP.VarejOnline.Domain.Tests/Controllers/PedidoControllerTests.cs
+++ b/tests/LexosHub.ERP.VarejOnline.Domain.Tests/Controllers/PedidoControllerTests.cs
@@ -1,58 +1,120 @@
-//using System.Net;
-//using System.Threading.Tasks;
-//using LexosHub.ERP.VarejOnline.Api.Controllers.Pedido;
-//using LexosHub.ERP.VarejOnline.Domain.Interfaces.Services;
-//using LexosHub.ERP.VarejOnline.Infra.CrossCutting.Default;
-//using LexosHub.ERP.VarejOnline.Infra.VarejOnlineApi.Responses;
-//using Microsoft.AspNetCore.Mvc;
-//using Moq;
-//using Xunit;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Lexos.Hub.Sync.Models.Pedido;
+using LexosHub.ERP.VarejOnline.Api.Controllers.Pedido;
+using LexosHub.ERP.VarejOnline.Infra.Messaging.Dispatcher;
+using LexosHub.ERP.VarejOnline.Infra.Messaging.Events;
+using LexosHub.ERP.VarejOnline.Infra.Messaging.Events.Pedido;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using Xunit;
 
-//namespace LexosHub.ERP.VarejOnline.Domain.Tests.Controllers
-//{
-//    public class PedidoControllerTests
-//    {
-//        private readonly Mock<IPedidoService> _service = new();
-//        private PedidoController CreateController() => new(_service.Object);
+namespace LexosHub.ERP.VarejOnline.Domain.Tests.Controllers
+{
+    public class PedidoControllerTests
+    {
+        private readonly Mock<IEventDispatcher> _dispatcher = new();
 
-//        [Fact]
-//        public async Task AlterarStatusPedido_ShouldReturnOk_WhenSuccess()
-//        {
-//            var response = new Response<PedidoResponse> { Result = new PedidoResponse(), StatusCode = HttpStatusCode.OK };
-//            _service.Setup(s => s.AlterarStatusPedido("hub", 1, "novo")).ReturnsAsync(response);
+        private PedidoController CreateController() => new(_dispatcher.Object);
 
-//            var controller = CreateController();
-//            var result = await controller.AlterarStatusPedido("hub", 1, "novo");
+        [Fact]
+        public async Task EnviarPedido_ShouldDispatchOrderCreatedEvent_WhenPedidoIsValid()
+        {
+            var pedido = new PedidoView { PedidoId = 1 };
+            const string hubKey = "hub";
+            var controller = CreateController();
 
-//            var ok = Assert.IsType<OkObjectResult>(result);
-//            Assert.Same(response, ok.Value);
-//            _service.Verify(s => s.AlterarStatusPedido("hub", 1, "novo"), Times.Once);
-//        }
+            var result = await controller.EnviarPedido(pedido, hubKey);
 
-//        [Fact]
-//        public async Task AlterarStatusPedido_ShouldReturnBadRequest_WhenServiceReturnsBadRequest()
-//        {
-//            var response = new Response<PedidoResponse> { Error = new ErrorResult("bad"), StatusCode = HttpStatusCode.BadRequest };
-//            _service.Setup(s => s.AlterarStatusPedido("hub", 1, "novo")).ReturnsAsync(response);
+            Assert.IsType<OkResult>(result);
+            _dispatcher.Verify(
+                d => d.DispatchAsync(
+                    It.Is<BaseEvent>(@event =>
+                        @event is OrderCreated orderCreated &&
+                        orderCreated.HubKey == hubKey &&
+                        ReferenceEquals(orderCreated.Pedido, pedido)),
+                    It.IsAny<CancellationToken>()),
+                Times.Once);
+        }
 
-//            var controller = CreateController();
-//            var result = await controller.AlterarStatusPedido("hub", 1, "novo");
+        [Fact]
+        public async Task EnviarPedido_ShouldThrowArgumentNullException_WhenPedidoIsNull()
+        {
+            var controller = CreateController();
 
-//            var bad = Assert.IsType<BadRequestObjectResult>(result);
-//            Assert.Same(response, bad.Value);
-//        }
+            await Assert.ThrowsAsync<ArgumentNullException>(() => controller.EnviarPedido(null!, "hub"));
+            _dispatcher.Verify(
+                d => d.DispatchAsync(It.IsAny<BaseEvent>(), It.IsAny<CancellationToken>()),
+                Times.Never);
+        }
 
-//        [Fact]
-//        public async Task AlterarStatusPedido_ShouldReturnConflict_WhenServiceReturnsConflict()
-//        {
-//            var response = new Response<PedidoResponse> { Error = new ErrorResult("conflict"), StatusCode = HttpStatusCode.Conflict };
-//            _service.Setup(s => s.AlterarStatusPedido("hub", 1, "novo")).ReturnsAsync(response);
+        [Fact]
+        public async Task AlterarStatusPedidoEntregue_ShouldDispatchOrderDeliveredEvent_WhenHubKeyIsValid()
+        {
+            const string hubKey = "hub";
+            const long pedidoErpId = 123;
+            var controller = CreateController();
 
-//            var controller = CreateController();
-//            var result = await controller.AlterarStatusPedido("hub", 1, "novo");
+            var result = await controller.AlterarStatusPedidoEntregue(hubKey, pedidoErpId);
 
-//            var conflict = Assert.IsType<ConflictObjectResult>(result);
-//            Assert.Same(response, conflict.Value);
-//        }
-//    }
-//}
+            Assert.IsType<OkResult>(result);
+            _dispatcher.Verify(
+                d => d.DispatchAsync(
+                    It.Is<BaseEvent>(@event =>
+                        @event is OrderDelivered orderDelivered &&
+                        orderDelivered.HubKey == hubKey &&
+                        orderDelivered.PedidoERPId == pedidoErpId),
+                    It.IsAny<CancellationToken>()),
+                Times.Once);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData(" ")]
+        public async Task AlterarStatusPedidoEntregue_ShouldThrowArgumentNullException_WhenHubKeyIsNullOrWhitespace(string hubKey)
+        {
+            var controller = CreateController();
+
+            await Assert.ThrowsAsync<ArgumentNullException>(() => controller.AlterarStatusPedidoEntregue(hubKey!, 123));
+            _dispatcher.Verify(
+                d => d.DispatchAsync(It.IsAny<BaseEvent>(), It.IsAny<CancellationToken>()),
+                Times.Never);
+        }
+
+        [Fact]
+        public async Task AlterarStatusPedidoEnviado_ShouldDispatchOrderShippedEvent_WhenHubKeyIsValid()
+        {
+            const string hubKey = "hub";
+            const long pedidoErpId = 456;
+            var controller = CreateController();
+
+            var result = await controller.AlterarStatusPedidoEnviado(hubKey, pedidoErpId);
+
+            Assert.IsType<OkResult>(result);
+            _dispatcher.Verify(
+                d => d.DispatchAsync(
+                    It.Is<BaseEvent>(@event =>
+                        @event is OrderShipped orderShipped &&
+                        orderShipped.HubKey == hubKey &&
+                        orderShipped.PedidoERPId == pedidoErpId),
+                    It.IsAny<CancellationToken>()),
+                Times.Once);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData(" ")]
+        public async Task AlterarStatusPedidoEnviado_ShouldThrowArgumentNullException_WhenHubKeyIsNullOrWhitespace(string hubKey)
+        {
+            var controller = CreateController();
+
+            await Assert.ThrowsAsync<ArgumentNullException>(() => controller.AlterarStatusPedidoEnviado(hubKey!, 456));
+            _dispatcher.Verify(
+                d => d.DispatchAsync(It.IsAny<BaseEvent>(), It.IsAny<CancellationToken>()),
+                Times.Never);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- rewrite PedidoController unit tests to inject a mocked IEventDispatcher
- cover each action to ensure the expected event and payload are dispatched
- validate null or whitespace arguments according to the controller logic

## Testing
- dotnet test tests/LexosHub.ERP.VarejOnline.Domain.Tests/LexosHub.ERP.VarejOnline.Domain.Tests.csproj *(fails: dotnet CLI not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cdc06731d88328ac08eb6780b3d463