### PR TITLE
Add order cancellation event handling

### DIFF
--- a/src/LexosHub.ERP.VarejOnline.Api/Controllers/Pedido/PedidoController.cs
+++ b/src/LexosHub.ERP.VarejOnline.Api/Controllers/Pedido/PedidoController.cs
@@ -60,6 +60,21 @@ namespace LexosHub.ERP.VarejOnline.Api.Controllers.Pedido
             await _dispatcher.DispatchAsync(orderCreatedEvent, new CancellationToken());
             return Ok();
         }
+
+        [HttpPost("{erpPedidoId:long}/cancelar")]
+        public async Task<IActionResult> CancelarPedido(long erpPedidoId, string hubKey)
+        {
+            if (string.IsNullOrWhiteSpace(hubKey)) throw new ArgumentNullException(nameof(hubKey));
+
+            var orderCancelledEvent = new OrderCancelled
+            {
+                HubKey = hubKey,
+                PedidoERPId = erpPedidoId
+            };
+
+            await _dispatcher.DispatchAsync(orderCancelledEvent, new CancellationToken());
+            return Ok();
+        }
     }
 }
 

--- a/src/LexosHub.ERP.VarejOnline.Api/Program.cs
+++ b/src/LexosHub.ERP.VarejOnline.Api/Program.cs
@@ -99,6 +99,7 @@ try
     builder.Services.AddTransient<IEventHandler<StocksRequested>, StocksRequestedEventHandler>();
     builder.Services.AddTransient<IEventHandler<CriarProdutosSimples>, CriarProdutosSimplesEventHandler>();
     builder.Services.AddTransient<IEventHandler<OrderCreated>, OrderCreatedEventHandler>();
+    builder.Services.AddTransient<IEventHandler<OrderCancelled>, OrderCancelledEventHandler>();
     builder.Services.AddTransient<IEventHandler<OrderShipped>, OrderShippedEventHandler>();
     builder.Services.AddTransient<IEventHandler<OrderDelivered>, OrderDeliveredEventHandler>();
     builder.Services.AddTransient<IEventHandler<CriarProdutosConfiguraveis>, CriarProdutosConfiguraveisEventHandler>();

--- a/src/LexosHub.ERP.VarejOnline.Infra.ErpApi/Interfaces/IVarejoOnlineApiService.cs
+++ b/src/LexosHub.ERP.VarejOnline.Infra.ErpApi/Interfaces/IVarejoOnlineApiService.cs
@@ -26,4 +26,5 @@ public interface IVarejOnlineApiService
     Task<Response<List<TerceiroResponse>>> GetTerceirosAsync(string token, TerceiroQueryRequest request);
     Task<Response<OperationResponse>> CreateTerceiroAsync(string token, TerceiroRequest request);
     Task<Response<OperationResponse>> AlterarStatusPedidoAsync(string token, AlterarStatusPedidoRequest request);
+    Task<Response<OperationResponse>> CancelarPedidoAsync(string token, long pedidoErpId);
 }

--- a/src/LexosHub.ERP.VarejOnline.Infra.ErpApi/Services/VarejoOnlineApiService.cs
+++ b/src/LexosHub.ERP.VarejOnline.Infra.ErpApi/Services/VarejoOnlineApiService.cs
@@ -270,10 +270,18 @@ namespace LexosHub.ERP.VarejOnline.Infra.VarejOnlineApi.Services
             var resource = $"apps/api/pedidos/alterar-status";
             var restRequest = new RestRequest(resource, Method.Post)
                                 .AddHeader("Content-Type", "application/json")
-                                .AddJsonBody(request);            
+                                .AddJsonBody(request);
             var operationRespnse = await ExecuteAsync<OperationResponse>(restRequest, token);
 
             return operationRespnse;
+        }
+
+        public async Task<Response<OperationResponse>> CancelarPedidoAsync(string token, long pedidoErpId)
+        {
+            var resource = $"apps/api/pedidos/{pedidoErpId}/cancelar";
+            var restRequest = new RestRequest(resource, Method.Post);
+
+            return await ExecuteAsync<OperationResponse>(restRequest, token);
         }
 
         #endregion

--- a/src/LexosHub.ERP.VarejOnline.Infra.Messaging/Events/Pedido/OrderCancelled.cs
+++ b/src/LexosHub.ERP.VarejOnline.Infra.Messaging/Events/Pedido/OrderCancelled.cs
@@ -1,0 +1,8 @@
+namespace LexosHub.ERP.VarejOnline.Infra.Messaging.Events.Pedido
+{
+    public class OrderCancelled : BaseEvent
+    {
+        public string HubKey { get; set; } = null!;
+        public long PedidoERPId { get; set; }
+    }
+}

--- a/src/LexosHub.ERP.VarejOnline.Infra.Messaging/Handlers/Pedido/OrderCancelledEventHandler.cs
+++ b/src/LexosHub.ERP.VarejOnline.Infra.Messaging/Handlers/Pedido/OrderCancelledEventHandler.cs
@@ -1,0 +1,44 @@
+using System.Threading;
+using System.Threading.Tasks;
+using LexosHub.ERP.VarejOnline.Domain.Interfaces.Services;
+using LexosHub.ERP.VarejOnline.Infra.Messaging.Events.Pedido;
+using Microsoft.Extensions.Logging;
+
+namespace LexosHub.ERP.VarejOnline.Infra.Messaging.Handlers.Pedido
+{
+    public class OrderCancelledEventHandler : IEventHandler<OrderCancelled>
+    {
+        private readonly ILogger<OrderCancelledEventHandler> _logger;
+        private readonly IIntegrationService _integrationService;
+        private readonly IVarejOnlineApiService _apiService;
+
+        public OrderCancelledEventHandler(
+            ILogger<OrderCancelledEventHandler> logger,
+            IIntegrationService integrationService,
+            IVarejOnlineApiService apiService)
+        {
+            _logger = logger;
+            _integrationService = integrationService;
+            _apiService = apiService;
+        }
+
+        public async Task HandleAsync(OrderCancelled @event, CancellationToken cancellationToken)
+        {
+            _logger.LogInformation($"Cancelamento de Pedido | PedidoERPId:  {@event.PedidoERPId}");
+
+            if (@event != null)
+            {
+                var integration = await _integrationService.GetIntegrationByKeyAsync(@event.HubKey);
+
+                var token = integration.Result!.Token;
+
+                var response = await _apiService.CancelarPedidoAsync(token!, @event.PedidoERPId);
+
+                if (!response.IsSuccess)
+                {
+                    //tratar erro do processo
+                }
+            }
+        }
+    }
+}

--- a/src/LexosHub.ERP.VarejOnline.Infra.Messaging/Resolver/EntityTypeResolver.cs
+++ b/src/LexosHub.ERP.VarejOnline.Infra.Messaging/Resolver/EntityTypeResolver.cs
@@ -20,6 +20,7 @@ namespace LexosHub.ERP.VarejOnline.Infra.Messaging.Dispatcher
             { nameof(StocksRequested), typeof(StocksRequested) },
             { nameof(InvoicesRequested), typeof(InvoicesRequested) },
             { nameof(OrderCreated), typeof(OrderCreated) },
+            { nameof(OrderCancelled), typeof(OrderCancelled) },
             { nameof(OrderDelivered), typeof(OrderDelivered) },
             { nameof(OrderShipped), typeof(OrderShipped) },
             { nameof(InitialSync), typeof(InitialSync) }

--- a/tests/LexosHub.ERP.VarejOnline.Domain.Tests/Messaging/OrderCancelledEventHandlerTests.cs
+++ b/tests/LexosHub.ERP.VarejOnline.Domain.Tests/Messaging/OrderCancelledEventHandlerTests.cs
@@ -1,0 +1,57 @@
+using System.Threading;
+using System.Threading.Tasks;
+using LexosHub.ERP.VarejOnline.Domain.DTOs.Integration;
+using LexosHub.ERP.VarejOnline.Domain.Interfaces.Services;
+using LexosHub.ERP.VarejOnline.Infra.CrossCutting.Default;
+using LexosHub.ERP.VarejOnline.Infra.ErpApi.Responses;
+using LexosHub.ERP.VarejOnline.Infra.Messaging.Events.Pedido;
+using LexosHub.ERP.VarejOnline.Infra.Messaging.Handlers.Pedido;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace LexosHub.ERP.VarejOnline.Domain.Tests.Messaging
+{
+    public class OrderCancelledEventHandlerTests
+    {
+        private readonly Mock<ILogger<OrderCancelledEventHandler>> _logger = new();
+        private readonly Mock<IIntegrationService> _integrationService = new();
+        private readonly Mock<IVarejOnlineApiService> _apiService = new();
+
+        private OrderCancelledEventHandler CreateHandler() =>
+            new(_logger.Object, _integrationService.Object, _apiService.Object);
+
+        [Fact]
+        public async Task HandleAsync_ShouldCancelOrderUsingTokenAndAwaitCall()
+        {
+            var integration = new IntegrationDto
+            {
+                Token = "token"
+            };
+
+            _integrationService.Setup(s => s.GetIntegrationByKeyAsync("hub"))
+                .ReturnsAsync(new Response<IntegrationDto>(integration));
+
+            var tcs = new TaskCompletionSource<Response<OperationResponse>>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            _apiService.Setup(a => a.CancelarPedidoAsync("token", 555))
+                .Returns(tcs.Task);
+
+            var handler = CreateHandler();
+
+            var handleTask = handler.HandleAsync(new OrderCancelled
+            {
+                HubKey = "hub",
+                PedidoERPId = 555
+            }, CancellationToken.None);
+
+            _apiService.Verify(a => a.CancelarPedidoAsync("token", 555), Times.Once);
+
+            Assert.False(handleTask.IsCompleted);
+
+            tcs.SetResult(new Response<OperationResponse>(new OperationResponse()));
+
+            await handleTask;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add OrderCancelled event and handler to trigger ERP cancellation calls
- extend VarejOnline API service with cancel endpoint and wire handler registration and API endpoint
- cover new handler with unit test verifying token usage and awaited API call

## Testing
- dotnet test *(fails: dotnet not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d3301780a08328baf13bdc219812fa