### PR TITLE
Propagar retorno de pedidos em cancelamento e atualização de status

### DIFF
--- a/src/LexosHub.ERP.VarejOnline.Api/Controllers/Pedido/PedidoController.cs
+++ b/src/LexosHub.ERP.VarejOnline.Api/Controllers/Pedido/PedidoController.cs
@@ -34,42 +34,48 @@ namespace LexosHub.ERP.VarejOnline.Api.Controllers.Pedido
         }
 
         [HttpPut("/alterar-status-entregue")]
-        public async Task<IActionResult> AlterarStatusPedidoEntregue(string hubKey, long erpPedidoId)
+        public async Task<IActionResult> AlterarStatusPedidoEntregue(string hubKey, long erpPedidoId, [FromBody] PedidoView pedido)
         {
             if (string.IsNullOrWhiteSpace(hubKey)) throw new ArgumentNullException(nameof(hubKey));
+            if (pedido == null) throw new ArgumentNullException(nameof(pedido));
 
             var orderCreatedEvent = new OrderDelivered
             {
                 HubKey = hubKey,
-                PedidoERPId = erpPedidoId
+                PedidoERPId = erpPedidoId,
+                Pedido = pedido
             };
             await _dispatcher.DispatchAsync(orderCreatedEvent, new CancellationToken());
             return Ok();
         }
 
         [HttpPut("/alterar-status-enviado")]
-        public async Task<IActionResult> AlterarStatusPedidoEnviado(string hubKey, long erpPedidoId)
+        public async Task<IActionResult> AlterarStatusPedidoEnviado(string hubKey, long erpPedidoId, [FromBody] PedidoView pedido)
         {
             if (string.IsNullOrWhiteSpace(hubKey)) throw new ArgumentNullException(nameof(hubKey));
+            if (pedido == null) throw new ArgumentNullException(nameof(pedido));
 
             var orderCreatedEvent = new OrderShipped
             {
                 HubKey = hubKey,
-                PedidoERPId = erpPedidoId
+                PedidoERPId = erpPedidoId,
+                Pedido = pedido
             };
             await _dispatcher.DispatchAsync(orderCreatedEvent, new CancellationToken());
             return Ok();
         }
 
         [HttpPost("{erpPedidoId:long}/cancelar")]
-        public async Task<IActionResult> CancelarPedido(long erpPedidoId, string hubKey)
+        public async Task<IActionResult> CancelarPedido(long erpPedidoId, string hubKey, [FromBody] PedidoView pedido)
         {
             if (string.IsNullOrWhiteSpace(hubKey)) throw new ArgumentNullException(nameof(hubKey));
+            if (pedido == null) throw new ArgumentNullException(nameof(pedido));
 
             var orderCancelledEvent = new OrderCancelled
             {
                 HubKey = hubKey,
-                PedidoERPId = erpPedidoId
+                PedidoERPId = erpPedidoId,
+                Pedido = pedido
             };
 
             await _dispatcher.DispatchAsync(orderCancelledEvent, new CancellationToken());

--- a/src/LexosHub.ERP.VarejOnline.Infra.Messaging/Events/Pedido/OrderCancelled.cs
+++ b/src/LexosHub.ERP.VarejOnline.Infra.Messaging/Events/Pedido/OrderCancelled.cs
@@ -1,8 +1,11 @@
+using Lexos.Hub.Sync.Models.Pedido;
+
 namespace LexosHub.ERP.VarejOnline.Infra.Messaging.Events.Pedido
 {
     public class OrderCancelled : BaseEvent
     {
         public string HubKey { get; set; } = null!;
         public long PedidoERPId { get; set; }
+        public PedidoView Pedido { get; set; } = null!;
     }
 }

--- a/src/LexosHub.ERP.VarejOnline.Infra.Messaging/Events/Pedido/OrderDelivered.cs
+++ b/src/LexosHub.ERP.VarejOnline.Infra.Messaging/Events/Pedido/OrderDelivered.cs
@@ -1,8 +1,11 @@
-﻿namespace LexosHub.ERP.VarejOnline.Infra.Messaging.Events.Pedido
+using Lexos.Hub.Sync.Models.Pedido;
+
+namespace LexosHub.ERP.VarejOnline.Infra.Messaging.Events.Pedido
 {
     public class OrderDelivered : BaseEvent
     {
         public string HubKey { get; set; } = null!;
-        public long PedidoERPId { get; set; }  
+        public long PedidoERPId { get; set; }
+        public PedidoView Pedido { get; set; } = null!;
     }
 }

--- a/src/LexosHub.ERP.VarejOnline.Infra.Messaging/Events/Pedido/OrderShipped.cs
+++ b/src/LexosHub.ERP.VarejOnline.Infra.Messaging/Events/Pedido/OrderShipped.cs
@@ -1,8 +1,11 @@
-﻿namespace LexosHub.ERP.VarejOnline.Infra.Messaging.Events.Pedido
+using Lexos.Hub.Sync.Models.Pedido;
+
+namespace LexosHub.ERP.VarejOnline.Infra.Messaging.Events.Pedido
 {
     public class OrderShipped : BaseEvent
     {
         public string HubKey { get; set; } = null!;
         public long PedidoERPId { get; set; }
+        public PedidoView Pedido { get; set; } = null!;
     }
 }

--- a/src/LexosHub.ERP.VarejOnline.Infra.Messaging/Handlers/Pedido/OrderCancelledEventHandler.cs
+++ b/src/LexosHub.ERP.VarejOnline.Infra.Messaging/Handlers/Pedido/OrderCancelledEventHandler.cs
@@ -1,12 +1,16 @@
+using System;
 using System.Threading;
 using System.Threading.Tasks;
+using Lexos.SQS.Interface;
 using LexosHub.ERP.VarejOnline.Domain.Interfaces.Services;
+using LexosHub.ERP.VarejOnline.Infra.CrossCutting.Settings;
 using LexosHub.ERP.VarejOnline.Infra.Messaging.Events.Pedido;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
 namespace LexosHub.ERP.VarejOnline.Infra.Messaging.Handlers.Pedido
 {
-    public class OrderCancelledEventHandler : IEventHandler<OrderCancelled>
+    public class OrderCancelledEventHandler : PedidoEventHandlerBase, IEventHandler<OrderCancelled>
     {
         private readonly ILogger<OrderCancelledEventHandler> _logger;
         private readonly IIntegrationService _integrationService;
@@ -15,7 +19,10 @@ namespace LexosHub.ERP.VarejOnline.Infra.Messaging.Handlers.Pedido
         public OrderCancelledEventHandler(
             ILogger<OrderCancelledEventHandler> logger,
             IIntegrationService integrationService,
-            IVarejOnlineApiService apiService)
+            IVarejOnlineApiService apiService,
+            ISqsRepository syncInSqsRepository,
+            IOptions<SyncInConfig> syncInSqsConfig)
+            : base(syncInSqsRepository, syncInSqsConfig)
         {
             _logger = logger;
             _integrationService = integrationService;
@@ -24,21 +31,35 @@ namespace LexosHub.ERP.VarejOnline.Infra.Messaging.Handlers.Pedido
 
         public async Task HandleAsync(OrderCancelled @event, CancellationToken cancellationToken)
         {
-            _logger.LogInformation($"Cancelamento de Pedido | PedidoERPId:  {@event.PedidoERPId}");
+            if (@event == null) throw new ArgumentNullException(nameof(@event));
 
-            if (@event != null)
+            _logger.LogInformation("Cancelamento de Pedido | PedidoERPId:  {PedidoERPId}", @event.PedidoERPId);
+
+            if (@event.Pedido == null)
             {
-                var integration = await _integrationService.GetIntegrationByKeyAsync(@event.HubKey);
-
-                var token = integration.Result!.Token;
-
-                var response = await _apiService.CancelarPedidoAsync(token!, @event.PedidoERPId);
-
-                if (!response.IsSuccess)
-                {
-                    //tratar erro do processo
-                }
+                _logger.LogWarning("Pedido não informado para cancelamento do pedido ERP {PedidoERPId}", @event.PedidoERPId);
+                return;
             }
+
+            var integration = await _integrationService.GetIntegrationByKeyAsync(@event.HubKey);
+            var token = integration.Result?.Token ?? string.Empty;
+
+            var response = await _apiService.CancelarPedidoAsync(token, @event.PedidoERPId);
+
+            if (!response.IsSuccess)
+            {
+                _logger.LogError("Falha ao cancelar o pedido {PedidoERPId}: {Erro}", @event.PedidoERPId, response.Error?.Message);
+                return;
+            }
+
+            var pedidoView = @event.Pedido;
+            pedidoView.PedidoCancelado = true;
+            pedidoView.PedidoERPId ??= @event.PedidoERPId.ToString();
+
+            var recursoId = response.Result?.IdRecurso ?? @event.PedidoERPId.ToString();
+
+            var retorno = BuildPedidoRetornoView(pedidoView, recursoId, pedidoCancelado: true);
+            PublishPedidoRetorno(@event.HubKey, pedidoView.CanalId, retorno);
         }
     }
 }

--- a/src/LexosHub.ERP.VarejOnline.Infra.Messaging/Handlers/Pedido/OrderDeliveredEventHandler.cs
+++ b/src/LexosHub.ERP.VarejOnline.Infra.Messaging/Handlers/Pedido/OrderDeliveredEventHandler.cs
@@ -1,59 +1,75 @@
-﻿using LexosHub.ERP.VarejOnline.Domain.Interfaces.Services;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Lexos.SQS.Interface;
+using LexosHub.ERP.VarejOnline.Domain.Interfaces.Services;
+using LexosHub.ERP.VarejOnline.Infra.CrossCutting.Settings;
 using LexosHub.ERP.VarejOnline.Infra.ErpApi.Request.Pedido;
-using LexosHub.ERP.VarejOnline.Infra.Messaging.Events;
 using LexosHub.ERP.VarejOnline.Infra.Messaging.Events.Pedido;
 using Microsoft.Extensions.Logging;
-using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using Microsoft.Extensions.Options;
 
 namespace LexosHub.ERP.VarejOnline.Infra.Messaging.Handlers.Pedido
 {
-    public class OrderDeliveredEventHandler : IEventHandler<OrderDelivered>
+    public class OrderDeliveredEventHandler : PedidoEventHandlerBase, IEventHandler<OrderDelivered>
     {
         private readonly ILogger<OrderDeliveredEventHandler> _logger;
         private readonly IIntegrationService _integrationService;
         private readonly IVarejOnlineApiService _apiService;
 
-        public OrderDeliveredEventHandler(ILogger<OrderDeliveredEventHandler> logger, IIntegrationService integrationService, IVarejOnlineApiService apiService)
+        public OrderDeliveredEventHandler(
+            ILogger<OrderDeliveredEventHandler> logger,
+            IIntegrationService integrationService,
+            IVarejOnlineApiService apiService,
+            ISqsRepository syncInSqsRepository,
+            IOptions<SyncInConfig> syncInSqsConfig)
+            : base(syncInSqsRepository, syncInSqsConfig)
         {
             _logger = logger;
             _integrationService = integrationService;
             _apiService = apiService;
         }
+
         public async Task HandleAsync(OrderDelivered @event, CancellationToken cancellationToken)
         {
-            _logger.LogInformation($"Alteração de Status de Pedido | PedidoERPId:  {@event.PedidoERPId}");
-            if (@event != null)
+            if (@event == null) throw new ArgumentNullException(nameof(@event));
+
+            _logger.LogInformation("Alteração de Status (Entregue) | PedidoERPId:  {PedidoERPId}", @event.PedidoERPId);
+
+            if (@event.Pedido == null)
             {
-                var hubKey = @event.HubKey;
-                var pedidoERPId = @event.PedidoERPId;
-
-                var integration = await _integrationService.GetIntegrationByKeyAsync(hubKey);
-
-                var token = integration.Result!.Token;
-
-                var request = new AlterarStatusPedidoRequest
-                {
-                    IdPedido = @event.PedidoERPId,
-                    StatusPedidoVenda = new StatusPedidoVendaRequest
-                    {
-                        Id = integration.Result!.Settings!.StatusDelivered,
-                    }
-                };
-
-                var result = _apiService.AlterarStatusPedidoAsync(token!, request);
-
-                if(!result.IsCompleted)
-                {
-                    //tratar erro do processo
-                }
-
-                
+                _logger.LogWarning("Pedido não informado para atualização de status entregue do pedido ERP {PedidoERPId}", @event.PedidoERPId);
+                return;
             }
+
+            var integration = await _integrationService.GetIntegrationByKeyAsync(@event.HubKey);
+            var token = integration.Result?.Token ?? string.Empty;
+            var statusDelivered = integration.Result?.Settings?.StatusDelivered;
+
+            var request = new AlterarStatusPedidoRequest
+            {
+                IdPedido = @event.PedidoERPId,
+                StatusPedidoVenda = new StatusPedidoVendaRequest
+                {
+                    Id = statusDelivered
+                }
+            };
+
+            var response = await _apiService.AlterarStatusPedidoAsync(token, request);
+
+            if (!response.IsSuccess)
+            {
+                _logger.LogError("Falha ao alterar status para entregue do pedido {PedidoERPId}: {Erro}", @event.PedidoERPId, response.Error?.Message);
+                return;
+            }
+
+            var pedidoView = @event.Pedido;
+            pedidoView.PedidoERPId ??= @event.PedidoERPId.ToString();
+            pedidoView.PedidoStatusERPId = statusDelivered;
+
+            var recursoId = response.Result?.IdRecurso ?? @event.PedidoERPId.ToString();
+            var retorno = BuildPedidoRetornoView(pedidoView, recursoId, pedidoAlterado: true);
+            PublishPedidoRetorno(@event.HubKey, pedidoView.CanalId, retorno);
         }
     }
 }

--- a/src/LexosHub.ERP.VarejOnline.Infra.Messaging/Handlers/Pedido/OrderShippedEventHandler.cs
+++ b/src/LexosHub.ERP.VarejOnline.Infra.Messaging/Handlers/Pedido/OrderShippedEventHandler.cs
@@ -1,52 +1,75 @@
-﻿using LexosHub.ERP.VarejOnline.Domain.Interfaces.Services;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Lexos.SQS.Interface;
+using LexosHub.ERP.VarejOnline.Domain.Interfaces.Services;
+using LexosHub.ERP.VarejOnline.Infra.CrossCutting.Settings;
 using LexosHub.ERP.VarejOnline.Infra.ErpApi.Request.Pedido;
 using LexosHub.ERP.VarejOnline.Infra.Messaging.Events.Pedido;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
 namespace LexosHub.ERP.VarejOnline.Infra.Messaging.Handlers.Pedido
 {
-    public class OrderShippedEventHandler : IEventHandler<OrderShipped>
+    public class OrderShippedEventHandler : PedidoEventHandlerBase, IEventHandler<OrderShipped>
     {
         private readonly ILogger<OrderShippedEventHandler> _logger;
         private readonly IIntegrationService _integrationService;
         private readonly IVarejOnlineApiService _apiService;
 
-        public OrderShippedEventHandler(ILogger<OrderShippedEventHandler> logger, IIntegrationService integrationService, IVarejOnlineApiService apiService)
+        public OrderShippedEventHandler(
+            ILogger<OrderShippedEventHandler> logger,
+            IIntegrationService integrationService,
+            IVarejOnlineApiService apiService,
+            ISqsRepository syncInSqsRepository,
+            IOptions<SyncInConfig> syncInSqsConfig)
+            : base(syncInSqsRepository, syncInSqsConfig)
         {
             _logger = logger;
             _integrationService = integrationService;
             _apiService = apiService;
         }
+
         public async Task HandleAsync(OrderShipped @event, CancellationToken cancellationToken)
         {
-            _logger.LogInformation($"Alteração de Status de Pedido | PedidoERPId:  {@event.PedidoERPId}");
-            if (@event != null)
+            if (@event == null) throw new ArgumentNullException(nameof(@event));
+
+            _logger.LogInformation("Alteração de Status (Enviado) | PedidoERPId:  {PedidoERPId}", @event.PedidoERPId);
+
+            if (@event.Pedido == null)
             {
-                var hubKey = @event.HubKey;
-                var pedidoERPId = @event.PedidoERPId;
-
-                var integration = await _integrationService.GetIntegrationByKeyAsync(hubKey);
-
-                var token = integration.Result!.Token;
-
-                var request = new AlterarStatusPedidoRequest
-                {
-                    IdPedido = @event.PedidoERPId,
-                    StatusPedidoVenda = new StatusPedidoVendaRequest
-                    {
-                        Id = integration.Result!.Settings!.StatusShipped,
-                    }
-                };
-
-                var result = _apiService.AlterarStatusPedidoAsync(token!, request);
-
-                if (!result.IsCompleted)
-                {
-                    //tratar erro do processo
-                }
-
-
+                _logger.LogWarning("Pedido não informado para atualização de status enviado do pedido ERP {PedidoERPId}", @event.PedidoERPId);
+                return;
             }
+
+            var integration = await _integrationService.GetIntegrationByKeyAsync(@event.HubKey);
+            var token = integration.Result?.Token ?? string.Empty;
+            var statusShipped = integration.Result?.Settings?.StatusShipped;
+
+            var request = new AlterarStatusPedidoRequest
+            {
+                IdPedido = @event.PedidoERPId,
+                StatusPedidoVenda = new StatusPedidoVendaRequest
+                {
+                    Id = statusShipped
+                }
+            };
+
+            var response = await _apiService.AlterarStatusPedidoAsync(token, request);
+
+            if (!response.IsSuccess)
+            {
+                _logger.LogError("Falha ao alterar status para enviado do pedido {PedidoERPId}: {Erro}", @event.PedidoERPId, response.Error?.Message);
+                return;
+            }
+
+            var pedidoView = @event.Pedido;
+            pedidoView.PedidoERPId ??= @event.PedidoERPId.ToString();
+            pedidoView.PedidoStatusERPId = statusShipped;
+
+            var recursoId = response.Result?.IdRecurso ?? @event.PedidoERPId.ToString();
+            var retorno = BuildPedidoRetornoView(pedidoView, recursoId, pedidoAlterado: true);
+            PublishPedidoRetorno(@event.HubKey, pedidoView.CanalId, retorno);
         }
     }
 }

--- a/src/LexosHub.ERP.VarejOnline.Infra.Messaging/Handlers/Pedido/PedidoEventHandlerBase.cs
+++ b/src/LexosHub.ERP.VarejOnline.Infra.Messaging/Handlers/Pedido/PedidoEventHandlerBase.cs
@@ -1,0 +1,78 @@
+using System;
+using Lexos.Hub.Sync;
+using Lexos.Hub.Sync.Enums;
+using Lexos.Hub.Sync.Models.Pedido;
+using Lexos.SQS.Interface;
+using LexosHub.ERP.VarejOnline.Infra.CrossCutting.Settings;
+using Microsoft.Extensions.Options;
+using Newtonsoft.Json;
+
+namespace LexosHub.ERP.VarejOnline.Infra.Messaging.Handlers.Pedido
+{
+    public abstract class PedidoEventHandlerBase
+    {
+        private readonly ISqsRepository _syncInSqsRepository;
+        private readonly string _queueNamePrefix = "notificacao-syncin-";
+
+        protected PedidoEventHandlerBase(ISqsRepository syncInSqsRepository, IOptions<SyncInConfig> syncInSqsConfig)
+        {
+            _syncInSqsRepository = syncInSqsRepository ?? throw new ArgumentNullException(nameof(syncInSqsRepository));
+            if (syncInSqsConfig == null) throw new ArgumentNullException(nameof(syncInSqsConfig));
+
+            var config = syncInSqsConfig.Value ?? throw new ArgumentException("SyncIn configuration must be provided.");
+            var queueUrl = $"{config.SQSBaseUrl}{config.SQSAccessKeyId}/{config.SQSName}";
+
+            _syncInSqsRepository.IniciarFila(queueUrl);
+        }
+
+        protected void PublishPedidoRetorno(string hubKey, short plataformaId, PedidoRetornoView retorno)
+        {
+            if (string.IsNullOrWhiteSpace(hubKey)) throw new ArgumentException("Hub key is required.", nameof(hubKey));
+            if (retorno == null) throw new ArgumentNullException(nameof(retorno));
+
+            var notificacao = new NotificacaoAtualizacaoModel
+            {
+                Chave = hubKey,
+                DataHora = DateTime.UtcNow,
+                Json = JsonConvert.SerializeObject(retorno),
+                TipoProcesso = TipoProcessoAtualizacao.Pedido,
+                PlataformaId = plataformaId
+            };
+
+            _syncInSqsRepository.AdicionarMensagemFilaFifo(notificacao, $"{_queueNamePrefix}{hubKey}");
+        }
+
+        protected static PedidoRetornoView BuildPedidoRetornoView(
+            PedidoView pedido,
+            string? id,
+            bool? pedidoIncluido = null,
+            bool? pedidoAlterado = null,
+            bool? pedidoCancelado = null,
+            bool? pedidoIgnorado = null,
+            bool erro = false,
+            string? mensagem = null)
+        {
+            if (pedido == null) throw new ArgumentNullException(nameof(pedido));
+
+            var statusId = pedido.PedidoStatusERPId.HasValue
+                ? pedido.PedidoStatusERPId.Value > int.MaxValue
+                    ? int.MaxValue
+                    : (int)pedido.PedidoStatusERPId.Value
+                : 0;
+
+            return new PedidoRetornoView
+            {
+                PedidoId = pedido.PedidoId,
+                PedidoERPId = !string.IsNullOrWhiteSpace(id) ? id! : pedido.PedidoERPId ?? string.Empty,
+                PedidoERPStatusId = statusId,
+                NomePlataformaERP = pedido.Plataforma ?? string.Empty,
+                PedidoCancelado = pedidoCancelado ?? pedido.PedidoCancelado,
+                PedidoIncluido = pedidoIncluido ?? false,
+                PedidoAlterado = pedidoAlterado ?? false,
+                PedidoIgnorado = pedidoIgnorado ?? false,
+                Erro = erro,
+                Mensagem = mensagem ?? string.Empty
+            };
+        }
+    }
+}

--- a/tests/LexosHub.ERP.VarejOnline.Domain.Tests/Messaging/OrderCancelledEventHandlerTests.cs
+++ b/tests/LexosHub.ERP.VarejOnline.Domain.Tests/Messaging/OrderCancelledEventHandlerTests.cs
@@ -1,13 +1,21 @@
+using System;
 using System.Threading;
 using System.Threading.Tasks;
+using Lexos.Hub.Sync;
+using Lexos.Hub.Sync.Enums;
+using Lexos.Hub.Sync.Models.Pedido;
+using Lexos.SQS.Interface;
 using LexosHub.ERP.VarejOnline.Domain.DTOs.Integration;
 using LexosHub.ERP.VarejOnline.Domain.Interfaces.Services;
 using LexosHub.ERP.VarejOnline.Infra.CrossCutting.Default;
+using LexosHub.ERP.VarejOnline.Infra.CrossCutting.Settings;
 using LexosHub.ERP.VarejOnline.Infra.ErpApi.Responses;
 using LexosHub.ERP.VarejOnline.Infra.Messaging.Events.Pedido;
 using LexosHub.ERP.VarejOnline.Infra.Messaging.Handlers.Pedido;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Moq;
+using Newtonsoft.Json;
 using Xunit;
 
 namespace LexosHub.ERP.VarejOnline.Domain.Tests.Messaging
@@ -17,9 +25,16 @@ namespace LexosHub.ERP.VarejOnline.Domain.Tests.Messaging
         private readonly Mock<ILogger<OrderCancelledEventHandler>> _logger = new();
         private readonly Mock<IIntegrationService> _integrationService = new();
         private readonly Mock<IVarejOnlineApiService> _apiService = new();
+        private readonly Mock<ISqsRepository> _sqsRepository = new();
+        private readonly IOptions<SyncInConfig> _syncInOptions = Options.Create(new SyncInConfig
+        {
+            SQSBaseUrl = "https://sqs/",
+            SQSAccessKeyId = "account",
+            SQSName = "queue.fifo"
+        });
 
         private OrderCancelledEventHandler CreateHandler() =>
-            new(_logger.Object, _integrationService.Object, _apiService.Object);
+            new(_logger.Object, _integrationService.Object, _apiService.Object, _sqsRepository.Object, _syncInOptions);
 
         [Fact]
         public async Task HandleAsync_ShouldCancelOrderUsingTokenAndAwaitCall()
@@ -37,21 +52,56 @@ namespace LexosHub.ERP.VarejOnline.Domain.Tests.Messaging
             _apiService.Setup(a => a.CancelarPedidoAsync("token", 555))
                 .Returns(tcs.Task);
 
+            string? startedQueue = null;
+            _sqsRepository.Setup(r => r.IniciarFila(It.IsAny<string>()))
+                .Callback<string>(url => startedQueue = url);
+
+            NotificacaoAtualizacaoModel? publishedNotification = null;
+            string? publishedGroupId = null;
+            _sqsRepository.Setup(r => r.AdicionarMensagemFilaFifo(It.IsAny<NotificacaoAtualizacaoModel>(), It.IsAny<string>()))
+                .Callback<NotificacaoAtualizacaoModel, string>((notification, groupId) =>
+                {
+                    publishedNotification = notification;
+                    publishedGroupId = groupId;
+                });
+
             var handler = CreateHandler();
 
             var handleTask = handler.HandleAsync(new OrderCancelled
             {
                 HubKey = "hub",
-                PedidoERPId = 555
+                PedidoERPId = 555,
+                Pedido = new PedidoView
+                {
+                    PedidoId = 123,
+                    CanalId = 7,
+                    Plataforma = "Canal",
+                    PedidoCancelado = false
+                }
             }, CancellationToken.None);
 
             _apiService.Verify(a => a.CancelarPedidoAsync("token", 555), Times.Once);
 
             Assert.False(handleTask.IsCompleted);
 
-            tcs.SetResult(new Response<OperationResponse>(new OperationResponse()));
+            tcs.SetResult(new Response<OperationResponse>(new OperationResponse { IdRecurso = "999" }));
 
             await handleTask;
+
+            Assert.Equal("https://sqs/account/queue.fifo", startedQueue);
+            Assert.NotNull(publishedNotification);
+            Assert.Equal("hub", publishedNotification!.Chave);
+            Assert.Equal(TipoProcessoAtualizacao.Pedido, publishedNotification.TipoProcesso);
+            Assert.Equal((short)7, publishedNotification.PlataformaId);
+            Assert.Equal("notificacao-syncin-hub", publishedGroupId);
+
+            var retorno = JsonConvert.DeserializeObject<PedidoRetornoView>(publishedNotification.Json);
+            Assert.NotNull(retorno);
+            Assert.Equal(123, retorno!.PedidoId);
+            Assert.Equal("999", retorno.PedidoERPId);
+            Assert.True(retorno.PedidoCancelado);
+            Assert.False(retorno.PedidoIncluido);
+            Assert.False(retorno.PedidoAlterado);
         }
     }
 }

--- a/tests/LexosHub.ERP.VarejOnline.Domain.Tests/Messaging/OrderCreatedEventHandlerTests.cs
+++ b/tests/LexosHub.ERP.VarejOnline.Domain.Tests/Messaging/OrderCreatedEventHandlerTests.cs
@@ -8,9 +8,8 @@ using LexosHub.ERP.VarejOnline.Infra.CrossCutting.Settings;
 using LexosHub.ERP.VarejOnline.Infra.ErpApi.Request.Clientes;
 using LexosHub.ERP.VarejOnline.Infra.ErpApi.Request.Pedido;
 using LexosHub.ERP.VarejOnline.Infra.ErpApi.Responses;
-using LexosHub.ERP.VarejOnline.Infra.Messaging.Dispatcher;
 using LexosHub.ERP.VarejOnline.Infra.Messaging.Events;
-using LexosHub.ERP.VarejOnline.Infra.Messaging.Handlers;
+using LexosHub.ERP.VarejOnline.Infra.Messaging.Handlers.Pedido;
 using Lexos.SQS.Interface;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -28,7 +27,6 @@ namespace LexosHub.ERP.VarejOnline.Domain.Tests.Messaging
     public class OrderCreatedEventHandlerTests
     {
         private readonly Mock<ILogger<OrderCreatedEventHandler>> _logger = new();
-        private readonly Mock<IEventDispatcher> _dispatcher = new();
         private readonly Mock<IIntegrationService> _integrationService = new();
         private readonly Mock<IVarejOnlineApiService> _apiService = new();
         private readonly Mock<ISqsRepository> _sqsRepository = new();
@@ -40,7 +38,7 @@ namespace LexosHub.ERP.VarejOnline.Domain.Tests.Messaging
         });
 
         private OrderCreatedEventHandler CreateHandler() =>
-            new(_logger.Object, _dispatcher.Object, _integrationService.Object, _apiService.Object, _sqsRepository.Object, _syncInOptions);
+            new(_logger.Object, _integrationService.Object, _apiService.Object, _sqsRepository.Object, _syncInOptions);
 
         [Fact]
         public async Task HandleAsync_ShouldCreateTerceiroSendOrderAndPublishNotification()

--- a/tests/LexosHub.ERP.VarejOnline.Domain.Tests/Messaging/OrderDeliveredEventHandlerTests.cs
+++ b/tests/LexosHub.ERP.VarejOnline.Domain.Tests/Messaging/OrderDeliveredEventHandlerTests.cs
@@ -1,14 +1,21 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Lexos.Hub.Sync;
+using Lexos.Hub.Sync.Enums;
+using Lexos.Hub.Sync.Models.Pedido;
+using Lexos.SQS.Interface;
 using LexosHub.ERP.VarejOnline.Domain.DTOs.Integration;
 using LexosHub.ERP.VarejOnline.Domain.Interfaces.Services;
 using LexosHub.ERP.VarejOnline.Infra.CrossCutting.Default;
+using LexosHub.ERP.VarejOnline.Infra.CrossCutting.Settings;
 using LexosHub.ERP.VarejOnline.Infra.ErpApi.Request.Pedido;
 using LexosHub.ERP.VarejOnline.Infra.ErpApi.Responses;
 using LexosHub.ERP.VarejOnline.Infra.Messaging.Events.Pedido;
 using LexosHub.ERP.VarejOnline.Infra.Messaging.Handlers.Pedido;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Moq;
-using System.Threading;
-using System.Threading.Tasks;
+using Newtonsoft.Json;
 using Xunit;
 
 namespace LexosHub.ERP.VarejOnline.Domain.Tests.Messaging
@@ -18,9 +25,16 @@ namespace LexosHub.ERP.VarejOnline.Domain.Tests.Messaging
         private readonly Mock<ILogger<OrderDeliveredEventHandler>> _logger = new();
         private readonly Mock<IIntegrationService> _integrationService = new();
         private readonly Mock<IVarejOnlineApiService> _apiService = new();
+        private readonly Mock<ISqsRepository> _sqsRepository = new();
+        private readonly IOptions<SyncInConfig> _syncInOptions = Options.Create(new SyncInConfig
+        {
+            SQSBaseUrl = "https://sqs/",
+            SQSAccessKeyId = "account",
+            SQSName = "queue.fifo"
+        });
 
         private OrderDeliveredEventHandler CreateHandler() =>
-            new(_logger.Object, _integrationService.Object, _apiService.Object);
+            new(_logger.Object, _integrationService.Object, _apiService.Object, _sqsRepository.Object, _syncInOptions);
 
         [Fact]
         public async Task HandleAsync_ShouldUpdateStatusUsingDeliveredSettingAndAwaitCall()
@@ -42,12 +56,31 @@ namespace LexosHub.ERP.VarejOnline.Domain.Tests.Messaging
             _apiService.Setup(a => a.AlterarStatusPedidoAsync("token", It.IsAny<AlterarStatusPedidoRequest>()))
                 .Returns(tcs.Task);
 
+            string? startedQueue = null;
+            _sqsRepository.Setup(r => r.IniciarFila(It.IsAny<string>()))
+                .Callback<string>(url => startedQueue = url);
+
+            NotificacaoAtualizacaoModel? publishedNotification = null;
+            string? publishedGroupId = null;
+            _sqsRepository.Setup(r => r.AdicionarMensagemFilaFifo(It.IsAny<NotificacaoAtualizacaoModel>(), It.IsAny<string>()))
+                .Callback<NotificacaoAtualizacaoModel, string>((notification, groupId) =>
+                {
+                    publishedNotification = notification;
+                    publishedGroupId = groupId;
+                });
+
             var handler = CreateHandler();
 
             var handleTask = handler.HandleAsync(new OrderDelivered
             {
                 HubKey = "hub",
-                PedidoERPId = 987
+                PedidoERPId = 987,
+                Pedido = new PedidoView
+                {
+                    PedidoId = 456,
+                    CanalId = 9,
+                    Plataforma = "Marketplace"
+                }
             }, CancellationToken.None);
 
             _apiService.Verify(a => a.AlterarStatusPedidoAsync("token", It.Is<AlterarStatusPedidoRequest>(r =>
@@ -55,9 +88,25 @@ namespace LexosHub.ERP.VarejOnline.Domain.Tests.Messaging
 
             Assert.False(handleTask.IsCompleted);
 
-            tcs.SetResult(new Response<OperationResponse>(new OperationResponse()));
+            tcs.SetResult(new Response<OperationResponse>(new OperationResponse { IdRecurso = "555" }));
 
             await handleTask;
+
+            Assert.Equal("https://sqs/account/queue.fifo", startedQueue);
+            Assert.NotNull(publishedNotification);
+            Assert.Equal("hub", publishedNotification!.Chave);
+            Assert.Equal(TipoProcessoAtualizacao.Pedido, publishedNotification.TipoProcesso);
+            Assert.Equal((short)9, publishedNotification.PlataformaId);
+            Assert.Equal("notificacao-syncin-hub", publishedGroupId);
+
+            var retorno = JsonConvert.DeserializeObject<PedidoRetornoView>(publishedNotification.Json);
+            Assert.NotNull(retorno);
+            Assert.Equal(456, retorno!.PedidoId);
+            Assert.Equal("555", retorno.PedidoERPId);
+            Assert.Equal(321, retorno.PedidoERPStatusId);
+            Assert.False(retorno.PedidoIncluido);
+            Assert.True(retorno.PedidoAlterado);
+            Assert.False(retorno.PedidoCancelado);
         }
     }
 }

--- a/tests/LexosHub.ERP.VarejOnline.Domain.Tests/Messaging/OrderShippedEventHandlerTests.cs
+++ b/tests/LexosHub.ERP.VarejOnline.Domain.Tests/Messaging/OrderShippedEventHandlerTests.cs
@@ -1,14 +1,21 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Lexos.Hub.Sync;
+using Lexos.Hub.Sync.Enums;
+using Lexos.Hub.Sync.Models.Pedido;
+using Lexos.SQS.Interface;
 using LexosHub.ERP.VarejOnline.Domain.DTOs.Integration;
 using LexosHub.ERP.VarejOnline.Domain.Interfaces.Services;
 using LexosHub.ERP.VarejOnline.Infra.CrossCutting.Default;
+using LexosHub.ERP.VarejOnline.Infra.CrossCutting.Settings;
 using LexosHub.ERP.VarejOnline.Infra.ErpApi.Request.Pedido;
 using LexosHub.ERP.VarejOnline.Infra.ErpApi.Responses;
 using LexosHub.ERP.VarejOnline.Infra.Messaging.Events.Pedido;
 using LexosHub.ERP.VarejOnline.Infra.Messaging.Handlers.Pedido;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Moq;
-using System.Threading;
-using System.Threading.Tasks;
+using Newtonsoft.Json;
 using Xunit;
 
 namespace LexosHub.ERP.VarejOnline.Domain.Tests.Messaging
@@ -18,9 +25,16 @@ namespace LexosHub.ERP.VarejOnline.Domain.Tests.Messaging
         private readonly Mock<ILogger<OrderShippedEventHandler>> _logger = new();
         private readonly Mock<IIntegrationService> _integrationService = new();
         private readonly Mock<IVarejOnlineApiService> _apiService = new();
+        private readonly Mock<ISqsRepository> _sqsRepository = new();
+        private readonly IOptions<SyncInConfig> _syncInOptions = Options.Create(new SyncInConfig
+        {
+            SQSBaseUrl = "https://sqs/",
+            SQSAccessKeyId = "account",
+            SQSName = "queue.fifo"
+        });
 
         private OrderShippedEventHandler CreateHandler() =>
-            new(_logger.Object, _integrationService.Object, _apiService.Object);
+            new(_logger.Object, _integrationService.Object, _apiService.Object, _sqsRepository.Object, _syncInOptions);
 
         [Fact]
         public async Task HandleAsync_ShouldUpdateStatusUsingShippedSettingAndAwaitCall()
@@ -42,12 +56,31 @@ namespace LexosHub.ERP.VarejOnline.Domain.Tests.Messaging
             _apiService.Setup(a => a.AlterarStatusPedidoAsync("token", It.IsAny<AlterarStatusPedidoRequest>()))
                 .Returns(tcs.Task);
 
+            string? startedQueue = null;
+            _sqsRepository.Setup(r => r.IniciarFila(It.IsAny<string>()))
+                .Callback<string>(url => startedQueue = url);
+
+            NotificacaoAtualizacaoModel? publishedNotification = null;
+            string? publishedGroupId = null;
+            _sqsRepository.Setup(r => r.AdicionarMensagemFilaFifo(It.IsAny<NotificacaoAtualizacaoModel>(), It.IsAny<string>()))
+                .Callback<NotificacaoAtualizacaoModel, string>((notification, groupId) =>
+                {
+                    publishedNotification = notification;
+                    publishedGroupId = groupId;
+                });
+
             var handler = CreateHandler();
 
             var handleTask = handler.HandleAsync(new OrderShipped
             {
                 HubKey = "hub",
-                PedidoERPId = 432
+                PedidoERPId = 432,
+                Pedido = new PedidoView
+                {
+                    PedidoId = 654,
+                    CanalId = 11,
+                    Plataforma = "Canal"
+                }
             }, CancellationToken.None);
 
             _apiService.Verify(a => a.AlterarStatusPedidoAsync("token", It.Is<AlterarStatusPedidoRequest>(r =>
@@ -55,9 +88,25 @@ namespace LexosHub.ERP.VarejOnline.Domain.Tests.Messaging
 
             Assert.False(handleTask.IsCompleted);
 
-            tcs.SetResult(new Response<OperationResponse>(new OperationResponse()));
+            tcs.SetResult(new Response<OperationResponse>(new OperationResponse { IdRecurso = "888" }));
 
             await handleTask;
+
+            Assert.Equal("https://sqs/account/queue.fifo", startedQueue);
+            Assert.NotNull(publishedNotification);
+            Assert.Equal("hub", publishedNotification!.Chave);
+            Assert.Equal(TipoProcessoAtualizacao.Pedido, publishedNotification.TipoProcesso);
+            Assert.Equal((short)11, publishedNotification.PlataformaId);
+            Assert.Equal("notificacao-syncin-hub", publishedGroupId);
+
+            var retorno = JsonConvert.DeserializeObject<PedidoRetornoView>(publishedNotification.Json);
+            Assert.NotNull(retorno);
+            Assert.Equal(654, retorno!.PedidoId);
+            Assert.Equal("888", retorno.PedidoERPId);
+            Assert.Equal(654, retorno.PedidoERPStatusId);
+            Assert.False(retorno.PedidoIncluido);
+            Assert.True(retorno.PedidoAlterado);
+            Assert.False(retorno.PedidoCancelado);
         }
     }
 }


### PR DESCRIPTION
## Summary
- criar `PedidoEventHandlerBase` para construir o retorno de pedido e publicar notificações na fila
- atualizar os handlers de criação, cancelamento e alteração de status para reutilizar a lógica comum e enviar o retorno após o sucesso da operação
- ajustar os eventos e o controlador de pedidos para transportar `PedidoView` nas operações de cancelamento e mudança de status
- expandir os testes unitários cobrindo as novas notificações nos handlers de pedidos

## Testing
- `dotnet test` *(falha: comando não disponível no ambiente)*

------
https://chatgpt.com/codex/tasks/task_e_68d3e971aa408328a83484753a2c992e